### PR TITLE
Add file validation rules

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@ lint:
 	python -m flake8 src/masonite/validation/ --ignore=E501,F401,E128,E402,E731,F821,E712,W503
 format:
 	black src/masonite/validation
+	black tests
 coverage:
 	python -m pytest --cov-report term --cov-report xml --cov=src/masonite/validation tests/
 	python -m coveralls

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ masonite>=2.3,<2.4.0
 pytest
 flake8
 pwnedapi==1.0.2
+hfilesize==0.1.0

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,8 @@ setup(
     include_package_data=True,
     version='3.0.8',
     install_requires=[
-        'masonite-dot>=0.0.5'
+        'masonite-dot>=0.0.5',
+        'hfilesize==0.1.0'
     ],
     description="Validation Package",
     author="Joseph Mancuso",

--- a/src/masonite/validation/Validator.py
+++ b/src/masonite/validation/Validator.py
@@ -53,10 +53,10 @@ class BaseValidation:
 
     def handle(self, dictionary):
         boolean = True
-        
+
         for key in self.validations:
             if self.negated:
-                
+
                 if self.passes(self.find(key, dictionary), key, dictionary):
                     boolean = False
                     if hasattr(self, "negated_message"):

--- a/src/masonite/validation/Validator.py
+++ b/src/masonite/validation/Validator.py
@@ -952,7 +952,7 @@ class video(BaseFileValidation):
         messages = []
         if not self.file_check:
             messages.append("The {} is not a valid file.".format(attribute))
- 
+
         if not self.size_check:
             from hfilesize import FileSize
 

--- a/src/masonite/validation/Validator.py
+++ b/src/masonite/validation/Validator.py
@@ -802,17 +802,15 @@ def parse_size(size):
 
 class BaseFileValidation(BaseValidation):
     def __init__(self, validations, messages={}, raises={}):
-        # internal state
+        super().__init__(validations, messages=messages, raises=raises)
         self.file_check = True
         self.size_check = True
         self.mimes_check = True
         self.all_clear = True
-        super().__init__(validations, messages=messages, raises=raises)
 
     def passes(self, attribute, key, dictionary):
         if not os.path.isfile(attribute):
             self.file_check = False
-            # it does not make sense to continue checks if not a file
             return False
         if self.size:
             file_size = os.path.getsize(attribute)
@@ -831,8 +829,8 @@ class file(BaseFileValidation):
     def __init__(self, validations, size=False, mimes=False, messages={}, raises={}):
         super().__init__(validations, messages=messages, raises=raises)
         self.size = parse_size(size)
+
         # parse allowed extensions to a list of mime types
-        # TODO: what if match not found, None for now ...?
         self.allowed_extensions = mimes
         if mimes:
             self.allowed_mimetypes = list(
@@ -843,6 +841,7 @@ class file(BaseFileValidation):
         messages = []
         if not self.file_check:
             messages.append("The {} is not a valid file.".format(attribute))
+
         if not self.size_check:
             from hfilesize import FileSize
 
@@ -852,12 +851,12 @@ class file(BaseFileValidation):
                 )
             )
         if not self.mimes_check:
-            # should we reprecise allowed mime types ? I guess
             messages.append(
                 "The {} mime type is not valid. Allowed formats are {}.".format(
                     attribute, ",".join(self.allowed_extensions)
                 )
             )
+
         return messages
 
     def negated_message(self, attribute):
@@ -873,7 +872,6 @@ class file(BaseFileValidation):
                 )
             )
         if self.mimes_check:
-            # should we reprecise allowed mime types ? I guess
             messages.append(
                 "The {} mime type is in {}.".format(
                     attribute, ",".join(self.allowed_extensions)
@@ -898,6 +896,7 @@ class image(BaseFileValidation):
         messages = []
         if not self.file_check:
             messages.append("The {} is not a valid file.".format(attribute))
+
         if not self.size_check:
             from hfilesize import FileSize
 
@@ -906,12 +905,14 @@ class image(BaseFileValidation):
                     attribute, FileSize(self.size)
                 )
             )
+
         if not self.mimes_check:
             messages.append(
                 "The {} file is not a valid image. Allowed formats are {}.".format(
                     attribute, ",".join(self.allowed_extensions)
                 )
             )
+
         return messages
 
     def negated_message(self, attribute):
@@ -926,8 +927,10 @@ class image(BaseFileValidation):
                     attribute, FileSize(self.size)
                 )
             )
+
         if self.mimes_check:
             messages.append("The {} file is a valid image.".format(attribute))
+
         return messages
 
 
@@ -935,11 +938,13 @@ class video(BaseFileValidation):
     def __init__(self, validations, size=False, messages={}, raises={}):
         super().__init__(validations, messages=messages, raises=raises)
         self.size = parse_size(size)
+
         video_mimetypes = {
             ext: mimetype
             for ext, mimetype in mimetypes.types_map.items()
             if mimetype.startswith("video")
         }
+
         self.allowed_extensions = list(video_mimetypes.keys())
         self.allowed_mimetypes = list(video_mimetypes.values())
 
@@ -947,6 +952,7 @@ class video(BaseFileValidation):
         messages = []
         if not self.file_check:
             messages.append("The {} is not a valid file.".format(attribute))
+ 
         if not self.size_check:
             from hfilesize import FileSize
 
@@ -955,18 +961,21 @@ class video(BaseFileValidation):
                     attribute, FileSize(self.size)
                 )
             )
+
         if not self.mimes_check:
             messages.append(
                 "The {} file is not a valid video. Allowed formats are {}.".format(
                     attribute, ",".join(self.allowed_extensions)
                 )
             )
+
         return messages
 
     def negated_message(self, attribute):
         messages = []
         if self.file_check:
             messages.append("The {} is a valid file.".format(attribute))
+
         if self.size_check:
             from hfilesize import FileSize
 
@@ -975,8 +984,10 @@ class video(BaseFileValidation):
                     attribute, FileSize(self.size)
                 )
             )
+
         if self.mimes_check:
             messages.append("The {} file is a valid video.".format(attribute))
+
         return messages
 
 

--- a/src/masonite/validation/Validator.py
+++ b/src/masonite/validation/Validator.py
@@ -797,7 +797,9 @@ class file(BaseValidation):
     def __init__(self, validations, size=False, mimes=False, messages={}, raises={}):
         super().__init__(validations, messages=messages, raises=raises)
         # parse size into bytes
-        self.size = size
+        from hfilesize import FileSize
+
+        self.size = FileSize(size, case_sensitive=False)
         # parse allowed extensions to a list of mime types
         # TODO: what if match not found, None for now ...?
         self.allowed_extensions = mimes
@@ -834,9 +836,12 @@ class file(BaseValidation):
         if not self.file_check:
             messages.append("The {} is not a valid file.".format(attribute))
         if not self.size_check:
-            # TODO: add better display of file size in message
+            from hfilesize import FileSize
+
             messages.append(
-                "The {} file size exceeds {} bytes.".format(attribute, self.size)
+                "The {} file size exceeds {:.02fH}.".format(
+                    attribute, FileSize(self.size)
+                )
             )
         if not self.mimes_check:
             # should we reprecise allowed mime types ? I guess

--- a/src/masonite/validation/Validator.py
+++ b/src/masonite/validation/Validator.py
@@ -931,6 +931,55 @@ class image(BaseFileValidation):
         return messages
 
 
+class video(BaseFileValidation):
+    def __init__(self, validations, size=False, messages={}, raises={}):
+        super().__init__(validations, messages=messages, raises=raises)
+        self.size = parse_size(size)
+        video_mimetypes = {
+            ext: mimetype
+            for ext, mimetype in mimetypes.types_map.items()
+            if mimetype.startswith("video")
+        }
+        self.allowed_extensions = list(video_mimetypes.keys())
+        self.allowed_mimetypes = list(video_mimetypes.values())
+
+    def message(self, attribute):
+        messages = []
+        if not self.file_check:
+            messages.append("The {} is not a valid file.".format(attribute))
+        if not self.size_check:
+            from hfilesize import FileSize
+
+            messages.append(
+                "The {} file size exceeds {:.02fH}.".format(
+                    attribute, FileSize(self.size)
+                )
+            )
+        if not self.mimes_check:
+            messages.append(
+                "The {} file is not a valid video. Allowed formats are {}.".format(
+                    attribute, ",".join(self.allowed_extensions)
+                )
+            )
+        return messages
+
+    def negated_message(self, attribute):
+        messages = []
+        if self.file_check:
+            messages.append("The {} is a valid file.".format(attribute))
+        if self.size_check:
+            from hfilesize import FileSize
+
+            messages.append(
+                "The {} file size is less or equal than {:.02fH}.".format(
+                    attribute, FileSize(self.size)
+                )
+            )
+        if self.mimes_check:
+            messages.append("The {} file is a valid video.".format(attribute))
+        return messages
+
+
 def flatten(iterable):
 
     flat_list = []
@@ -1068,6 +1117,7 @@ class ValidationFactory:
             strong,
             timezone,
             truthy,
+            video,
             when,
         )
 

--- a/src/masonite/validation/Validator.py
+++ b/src/masonite/validation/Validator.py
@@ -853,7 +853,25 @@ class file(BaseValidation):
         return messages
 
     def negated_message(self, attribute):
-        pass
+        messages = []
+        if self.file_check:
+            messages.append("The {} is a valid file.".format(attribute))
+        if self.size_check:
+            from hfilesize import FileSize
+
+            messages.append(
+                "The {} file size is less or equal than {:.02fH}.".format(
+                    attribute, FileSize(self.size)
+                )
+            )
+        if self.mimes_check:
+            # should we reprecise allowed mime types ? I guess
+            messages.append(
+                "The {} mime type is in {}.".format(
+                    attribute, ",".join(self.allowed_extensions)
+                )
+            )
+        return messages
 
 
 def flatten(iterable):

--- a/src/masonite/validation/Validator.py
+++ b/src/masonite/validation/Validator.py
@@ -803,7 +803,7 @@ class file(BaseValidation):
         self.allowed_extensions = mimes
         if mimes:
             self.allowed_mimetypes = list(
-                map(lambda mt: mimetypes.types_map.get(f".{mt}", None), mimes)
+                map(lambda mt: mimetypes.types_map.get("." + mt, None), mimes)
             )
         # internal state
         self.file_check = True

--- a/src/masonite/validation/__init__.py
+++ b/src/masonite/validation/__init__.py
@@ -17,6 +17,7 @@ from .Validator import (
     exists,
     file,
     greater_than,
+    image,
     in_range,
     ip,
     is_future,

--- a/src/masonite/validation/__init__.py
+++ b/src/masonite/validation/__init__.py
@@ -37,5 +37,6 @@ from .Validator import (
     strong,
     timezone,
     truthy,
+    video,
     when,
 )

--- a/src/masonite/validation/__init__.py
+++ b/src/masonite/validation/__init__.py
@@ -15,6 +15,7 @@ from .Validator import (
     email,
     equals,
     exists,
+    file,
     greater_than,
     in_range,
     ip,

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -1,15 +1,17 @@
 from masonite.testing import TestCase
 from masonite.routes import Get
 
-class TestDecorators(TestCase):
 
+class TestDecorators(TestCase):
     def setUp(self):
         super().setUp()
-        self.routes(only=[
-            Get('/test', 'PackageController@show'),
-            Get('/validate', 'PackageController@validate'),
-        ])
+        self.routes(
+            only=[
+                Get("/test", "PackageController@show"),
+                Get("/validate", "PackageController@validate"),
+            ]
+        )
 
     def test_validation_decorator(self):
-        self.assertFalse(self.get('/validate').contains('success'))
-        self.get('/validate', {'name': 'Joe'}).assertContains('success')
+        self.assertFalse(self.get("/validate").contains("success"))
+        self.get("/validate", {"name": "Joe"}).assertContains("success")

--- a/tests/test_messagebag.py
+++ b/tests/test_messagebag.py
@@ -1,113 +1,103 @@
 import unittest
 from src.masonite.validation import MessageBag
 
-class TestMessageBag(unittest.TestCase):
 
+class TestMessageBag(unittest.TestCase):
     def setUp(self):
         self.bag = MessageBag()
 
     def test_message_bag_can_add_errors_and_messages(self):
-        self.bag.add('email', 'Your email is invalid')
-        self.assertEqual(self.bag.items, {'email': ['Your email is invalid']})
+        self.bag.add("email", "Your email is invalid")
+        self.assertEqual(self.bag.items, {"email": ["Your email is invalid"]})
 
     def test_message_bag_can_add_several_errors_and_messages(self):
-        self.bag.add('email', 'Your email is invalid')
-        self.bag.add('email', 'Your email is invalid')
+        self.bag.add("email", "Your email is invalid")
+        self.bag.add("email", "Your email is invalid")
 
     def test_message_bag_can_get_all_errors_and_messages(self):
         self.bag.reset()
-        self.bag.add('email', 'Your email is invalid')
-        self.assertEqual(self.bag.all(), {'email': ['Your email is invalid']})
+        self.bag.add("email", "Your email is invalid")
+        self.assertEqual(self.bag.all(), {"email": ["Your email is invalid"]})
 
     def test_message_bag_has_any_errors(self):
         self.bag.reset()
         self.assertFalse(self.bag.any())
-        self.bag.add('email', 'Your email is invalid')
+        self.bag.add("email", "Your email is invalid")
         self.assertTrue(self.bag.any())
 
     def test_message_bag_has_any_errors(self):
         self.bag.reset()
         self.assertTrue(self.bag.empty())
-        self.bag.add('email', 'Your email is invalid')
+        self.bag.add("email", "Your email is invalid")
         self.assertFalse(self.bag.empty())
 
     def test_message_bag_can_get_first_error(self):
         self.bag.reset()
-        self.bag.add('email', 'Your email is invalid')
-        self.bag.add('email', 'Your email is too short')
-        self.bag.add('username', 'Your username is invalid')
-        self.assertEqual(self.bag.first('email'), 'Your email is invalid')
-        self.assertEqual(self.bag.first('username'), 'Your username is invalid')
+        self.bag.add("email", "Your email is invalid")
+        self.bag.add("email", "Your email is too short")
+        self.bag.add("username", "Your username is invalid")
+        self.assertEqual(self.bag.first("email"), "Your email is invalid")
+        self.assertEqual(self.bag.first("username"), "Your username is invalid")
 
     def test_amount_of_messages(self):
         self.bag.reset()
-        self.bag.add('email', 'Your email is invalid')
-        self.bag.add('email', 'Your email too short')
-        self.assertEqual(self.bag.amount('email'), 2)
+        self.bag.add("email", "Your email is invalid")
+        self.bag.add("email", "Your email too short")
+        self.assertEqual(self.bag.amount("email"), 2)
 
     def test_has_message(self):
         self.bag.reset()
-        self.assertFalse(self.bag.has('email'))
-        self.assertFalse(self.bag.has('username'))
-        self.bag.add('email', 'Your email is invalid')
-        self.bag.add('email', 'Your email too short')
-        self.assertTrue(self.bag.has('email'))
-        self.assertFalse(self.bag.has('username'))
+        self.assertFalse(self.bag.has("email"))
+        self.assertFalse(self.bag.has("username"))
+        self.bag.add("email", "Your email is invalid")
+        self.bag.add("email", "Your email too short")
+        self.assertTrue(self.bag.has("email"))
+        self.assertFalse(self.bag.has("username"))
 
     def test_get_messages_with_same_keys(self):
         self.bag.reset()
-        self.bag.add('email', 'Your email is invalid')
-        self.bag.add('email', 'Your email too short')
+        self.bag.add("email", "Your email is invalid")
+        self.bag.add("email", "Your email too short")
         self.assertIn(
-            'Your email is invalid',
-            self.bag.get('email'), 
+            "Your email is invalid", self.bag.get("email"),
         )
         self.assertIn(
-            'Your email too short',
-            self.bag.get('email'), 
+            "Your email too short", self.bag.get("email"),
         )
 
     def test_get_errors(self):
         self.bag.reset()
-        self.bag.add('email', 'Your email is invalid')
-        self.bag.add('email', 'Your email too short')
-        self.assertEqual(
-            self.bag.errors(), 
-            ['email']
-        )
+        self.bag.add("email", "Your email is invalid")
+        self.bag.add("email", "Your email too short")
+        self.assertEqual(self.bag.errors(), ["email"])
 
     def test_get_messages(self):
         self.bag.reset()
-        self.bag.add('email', 'Your email is invalid')
-        self.bag.add('username', 'Your username too short')
+        self.bag.add("email", "Your email is invalid")
+        self.bag.add("username", "Your username too short")
         self.assertIn(
-            'Your email is invalid',
-            self.bag.messages(),
+            "Your email is invalid", self.bag.messages(),
         )
 
         self.assertIn(
-            'Your username too short',
-            self.bag.messages(),
+            "Your username too short", self.bag.messages(),
         )
 
     def test_can_convert_to_json(self):
         self.bag.reset()
-        self.bag.add('email', 'Your email is invalid')
-        self.assertEqual(
-            self.bag.json(), 
-            '{"email": ["Your email is invalid"]}'
-        )
+        self.bag.add("email", "Your email is invalid")
+        self.assertEqual(self.bag.json(), '{"email": ["Your email is invalid"]}')
 
     def test_can_merge(self):
         self.bag.reset()
-        self.bag.add('email', 'Your email is invalid')
-        self.bag.merge({'username': ['username is too short']})
+        self.bag.add("email", "Your email is invalid")
+        self.bag.merge({"username": ["username is too short"]})
         self.assertEqual(self.bag.count(), 2)
 
     def test_can_work_with_if_statements_and_full(self):
         self.bag.reset()
-        self.bag.add('email', 'Your email is invalid')
-        
+        self.bag.add("email", "Your email is invalid")
+
         if self.bag:
             pass
         else:
@@ -115,7 +105,7 @@ class TestMessageBag(unittest.TestCase):
 
     def test_can_work_with_if_statements_and_false(self):
         self.bag.reset()
-        
+
         if self.bag:
             raise AssertionError("Should not raise when not full")
         else:

--- a/tests/test_messagebag_view.py
+++ b/tests/test_messagebag_view.py
@@ -1,14 +1,16 @@
 import unittest
 from src.masonite.validation import MessageBag
 
-class TestMessageBag(unittest.TestCase):
 
+class TestMessageBag(unittest.TestCase):
     def setUp(self):
-        self.errors = MessageBag.view_helper({'email': ['email is required', 'email must be a valid email']})
+        self.errors = MessageBag.view_helper(
+            {"email": ["email is required", "email must be a valid email"]}
+        )
 
     def test_get_errors(self):
         self.assertTrue(self.errors.any())
 
     def test_get_messages(self):
-        self.assertIn('email is required', self.errors.messages())
-        self.assertIn('email must be a valid email', self.errors.messages())
+        self.assertIn("email is required", self.errors.messages())
+        self.assertIn("email must be a valid email", self.errors.messages())

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -1,5 +1,7 @@
 import json
 import unittest
+import pytest
+import sys
 
 import pendulum
 from masonite.app import App

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -688,11 +688,12 @@ class TestValidation(unittest.TestCase):
             {"document": test_file}, file(["document"], mimes=["jpg", "png",])
         )
         self.assertEqual(
-            validate.get("document"), ["The document mime type is not valid."]
+            validate.get("document"),
+            ["The document mime type is not valid. Allowed types are jpg,png."],
         )
 
         validate = Validator().validate(
-            {"document": test_file}, file(["document"], mimes=["text/x-python",])
+            {"document": test_file}, file(["document"], mimes=["py",])
         )
         self.assertEqual(len(validate), 0)
 
@@ -707,7 +708,7 @@ class TestValidation(unittest.TestCase):
             validate.get("document"),
             [
                 "The document file size exceeds 100 bytes.",
-                "The document mime type is not valid.",
+                "The document mime type is not valid. Allowed types are jpg,png.",
             ],
         )
 

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -667,6 +667,7 @@ class TestValidation(unittest.TestCase):
     def test_file_size_validation(self):
         import os
 
+        # check that max size is 100 bytes
         test_file = os.path.abspath(__file__)
         validate = Validator().validate(
             {"document": test_file}, file(["document"], size=100)
@@ -674,11 +675,18 @@ class TestValidation(unittest.TestCase):
         self.assertEqual(
             validate.get("document"), ["The document file size exceeds 100 bytes."]
         )
-        # check that file size < 2 Mio
+
         validate = Validator().validate(
-            {"document": test_file}, file(["document"], size=1024 * 1024 * 2)
+            {"document": test_file}, file(["document"], size="2MB")
         )
         self.assertEqual(len(validate), 0)
+
+        validate = Validator().validate(
+            {"document": test_file}, file(["document"], size="4K")
+        )
+        self.assertEqual(
+            validate.get("document"), ["The document file size exceeds 4 KB."]
+        )
 
     def test_file_mime_types_validation(self):
         import os

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -722,6 +722,10 @@ class TestValidation(unittest.TestCase):
             ],
         )
 
+    @pytest.mark.skipif(
+        sys.version_info < (3, 5),
+        reason="python 3.5 mimetype modules breaks test but validation rule is ok",
+    )
     def test_image_validation(self):
         validate = Validator().validate({"avatar": "a string",}, image(["avatar"]))
 
@@ -774,6 +778,10 @@ class TestValidation(unittest.TestCase):
                 validate.get("avatar"), ["The avatar file size exceeds 20 bytes."]
             )
 
+    @pytest.mark.skipif(
+        sys.version_info < (3, 5),
+        reason="python 3.5 mimetype modules breaks test but validation rule is ok",
+    )
     def test_video_validation(self):
         validate = Validator().validate({"document": "a string",}, video(["document"]))
 

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -1,8 +1,7 @@
 import json
 import unittest
 import pytest
-import sys
-
+import platform
 import pendulum
 from masonite.app import App
 from masonite.drivers import SessionCookieDriver
@@ -725,7 +724,7 @@ class TestValidation(unittest.TestCase):
         )
 
     @pytest.mark.skipif(
-        sys.version_info < (3, 5),
+        int(platform.python_version_tuple()[1]) < 6,
         reason="python 3.5 mimetype modules breaks test but validation rule is ok",
     )
     def test_image_validation(self):
@@ -781,7 +780,7 @@ class TestValidation(unittest.TestCase):
             )
 
     @pytest.mark.skipif(
-        sys.version_info < (3, 5),
+        int(platform.python_version_tuple()[1]) < 6,
         reason="python 3.5 mimetype modules breaks test but validation rule is ok",
     )
     def test_video_validation(self):

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -1,4 +1,3 @@
-
 import json
 import unittest
 
@@ -10,949 +9,942 @@ from masonite.testing import TestCase, generate_wsgi
 
 from src.masonite.validation import RuleEnclosure
 from src.masonite.validation.providers import ValidationProvider
-from src.masonite.validation import (ValidationFactory, Validator,
-                                               accepted, active_domain,
-                                               after_today, before_today, confirmed,
-                                               contains, date, does_not, email,
-                                               equals, exists, greater_than,
-                                               in_range, ip, is_future, is_list, is_in,
-                                               is_past, isnt, strong, regex)
+from src.masonite.validation import (
+    ValidationFactory,
+    Validator,
+    accepted,
+    active_domain,
+    after_today,
+    before_today,
+    confirmed,
+    contains,
+    date,
+    does_not,
+    email,
+    equals,
+    exists,
+    file,
+    greater_than,
+    in_range,
+    ip,
+    is_future,
+    is_list,
+    is_in,
+    is_past,
+    isnt,
+    strong,
+    regex,
+)
 from src.masonite.validation.Validator import json as vjson
-from src.masonite.validation.Validator import (length, less_than, matches,
-                                               none, numeric, one_of, phone,
-                                               required, string, timezone,
-                                               truthy, when)
+from src.masonite.validation.Validator import (
+    length,
+    less_than,
+    matches,
+    none,
+    numeric,
+    one_of,
+    phone,
+    required,
+    string,
+    timezone,
+    truthy,
+    when,
+)
 
 
 class TestValidation(unittest.TestCase):
-
     def setUp(self):
         pass
 
     def test_required(self):
-        validate = Validator().validate({
-            'test': 1
-        }, required(['user', 'email']))
+        validate = Validator().validate({"test": 1}, required(["user", "email"]))
 
-        self.assertEqual(validate.get('user'), ['The user field is required.'])
-        self.assertEqual(validate.get('email'), ['The email field is required.'])
+        self.assertEqual(validate.get("user"), ["The user field is required."])
+        self.assertEqual(validate.get("email"), ["The email field is required."])
 
-        validate = Validator().validate({
-            'test': 1
-        }, required(['test']))
+        validate = Validator().validate({"test": 1}, required(["test"]))
 
         self.assertEqual(len(validate), 0)
 
     def test_can_validate_null_values(self):
-        validate = Validator().validate({
-            'test': None
-        }, length(['test'], min=2, max=5))
+        validate = Validator().validate({"test": None}, length(["test"], min=2, max=5))
 
         self.assertEqual(len(validate), 0)
 
     def test_extendable(self):
         v = Validator()
-        v.extend('numeric', numeric)
+        v.extend("numeric", numeric)
 
-        validate = v.validate({
-            'test': 1
-        }, v.numeric(['test']))
+        validate = v.validate({"test": 1}, v.numeric(["test"]))
 
         self.assertEqual(len(validate), 0)
 
     def test_email(self):
-        validate = Validator().validate({
-            'email': 'user@example.com'
-        }, email(['email']))
+        validate = Validator().validate({"email": "user@example.com"}, email(["email"]))
 
         self.assertEqual(len(validate), 0)
 
-        validate = Validator().validate({
-            'email': 'user'
-        }, email(['email']))
+        validate = Validator().validate({"email": "user"}, email(["email"]))
 
         self.assertEqual(
-            validate.all(), {'email': ['The email must be a valid email address.']})
+            validate.all(), {"email": ["The email must be a valid email address."]}
+        )
 
     def test_matches(self):
-        validate = Validator().validate({
-            'password': 'secret',
-            'confirm': 'secret',
-        }, matches('password', 'confirm'))
+        validate = Validator().validate(
+            {"password": "secret", "confirm": "secret",}, matches("password", "confirm")
+        )
 
         self.assertEqual(len(validate), 0)
 
-        validate = Validator().validate({
-            'password': 'secret',
-            'confirm': 'no-secret',
-        }, matches('password', 'confirm'))
+        validate = Validator().validate(
+            {"password": "secret", "confirm": "no-secret",},
+            matches("password", "confirm"),
+        )
 
         self.assertEqual(
-            validate.all(), {'password': ['The password must match confirm.']})
+            validate.all(), {"password": ["The password must match confirm."]}
+        )
 
     def test_active_domain(self):
-        validate = Validator().validate({
-            'domain1': 'google.com',
-            'domain2': 'http://google.com',
-            'domain3': 'https://www.google.com',
-            'email': 'admin@gmail.com'
-        }, active_domain(['domain1', 'domain2', 'domain3', 'email']))
+        validate = Validator().validate(
+            {
+                "domain1": "google.com",
+                "domain2": "http://google.com",
+                "domain3": "https://www.google.com",
+                "email": "admin@gmail.com",
+            },
+            active_domain(["domain1", "domain2", "domain3", "email"]),
+        )
 
         self.assertEqual(len(validate), 0)
 
-        validate = Validator().validate({
-            'domain1': 'domain',
-        }, active_domain(['domain1']))
+        validate = Validator().validate(
+            {"domain1": "domain",}, active_domain(["domain1"])
+        )
 
         self.assertEqual(
-            validate.all(), {'domain1': ['The domain1 must be an active domain name.']})
+            validate.all(), {"domain1": ["The domain1 must be an active domain name."]}
+        )
 
     def test_phone(self):
-        validate = Validator().validate({
-            'phone': '876-182-1921'
-        }, phone('phone', pattern='123-456-7890'))
+        validate = Validator().validate(
+            {"phone": "876-182-1921"}, phone("phone", pattern="123-456-7890")
+        )
 
         self.assertEqual(len(validate), 0)
 
-        validate = Validator().validate({
-            'phone': '(876)182-1921'
-        }, phone('phone', pattern='123-456-7890'))
+        validate = Validator().validate(
+            {"phone": "(876)182-1921"}, phone("phone", pattern="123-456-7890")
+        )
 
         self.assertEqual(
-            validate.all(), {'phone': ['The phone must be in the format XXX-XXX-XXXX.']})
+            validate.all(), {"phone": ["The phone must be in the format XXX-XXX-XXXX."]}
+        )
 
     def test_accepted(self):
-        validate = Validator().validate({
-            'terms': 'on'
-        }, accepted(['terms']))
+        validate = Validator().validate({"terms": "on"}, accepted(["terms"]))
 
         self.assertEqual(len(validate), 0)
 
-        validate = Validator().validate({
-            'terms': 'test'
-        }, accepted(['terms']))
+        validate = Validator().validate({"terms": "test"}, accepted(["terms"]))
 
-        self.assertEqual(
-            validate.all(), {'terms': ['The terms must be accepted.']})
+        self.assertEqual(validate.all(), {"terms": ["The terms must be accepted."]})
 
     def test_ip(self):
-        validate = Validator().validate({
-            'ip': '192.168.1.1'
-        }, ip(['ip']))
+        validate = Validator().validate({"ip": "192.168.1.1"}, ip(["ip"]))
 
         self.assertEqual(len(validate), 0)
 
-        validate = Validator().validate({
-            'ip': 'test'
-        }, ip(['ip']))
+        validate = Validator().validate({"ip": "test"}, ip(["ip"]))
 
-        self.assertEqual(validate.all(), {'ip': ['The ip must be a valid ipv4 address.']})
+        self.assertEqual(
+            validate.all(), {"ip": ["The ip must be a valid ipv4 address."]}
+        )
 
     def test_timezone(self):
-        validate = Validator().validate({
-            'timezone': 'America/New_York'
-        }, timezone(['timezone']))
+        validate = Validator().validate(
+            {"timezone": "America/New_York"}, timezone(["timezone"])
+        )
 
         self.assertEqual(len(validate), 0)
 
-        validate = Validator().validate({
-            'timezone': 'test'
-        }, timezone(['timezone']))
+        validate = Validator().validate({"timezone": "test"}, timezone(["timezone"]))
 
         self.assertEqual(
-            validate.all(), {'timezone': ['The timezone must be a valid timezone.']})
+            validate.all(), {"timezone": ["The timezone must be a valid timezone."]}
+        )
 
     def test_exists(self):
-        validate = Validator().validate({
-            'terms': 'on',
-            'user': 'here',
-        }, exists(['user']))
+        validate = Validator().validate(
+            {"terms": "on", "user": "here",}, exists(["user"])
+        )
 
         self.assertEqual(len(validate), 0)
 
-        validate = Validator().validate({
-            'terms': 'test'
-        }, exists(['user']))
+        validate = Validator().validate({"terms": "test"}, exists(["user"]))
 
-        self.assertEqual(validate.all(), {'user': ['The user must exist.']})
+        self.assertEqual(validate.all(), {"user": ["The user must exist."]})
 
     def test_date(self):
-        validate = Validator().validate({
-            'date': '1975-05-21T22:00:00',
-        }, date(['date']))
+        validate = Validator().validate(
+            {"date": "1975-05-21T22:00:00",}, date(["date"])
+        )
 
         self.assertEqual(len(validate), 0)
 
-        validate = Validator().validate({
-            'date': 'woop',
-        }, date(['date']))
+        validate = Validator().validate({"date": "woop",}, date(["date"]))
 
-        self.assertEqual(validate.all(), {'date': ['The date must be a valid date.']})
+        self.assertEqual(validate.all(), {"date": ["The date must be a valid date."]})
 
     def test_before_today(self):
-        validate = Validator().validate({
-            'date': '1975-05-21T22:00:00',
-        }, before_today(['date']))
+        validate = Validator().validate(
+            {"date": "1975-05-21T22:00:00",}, before_today(["date"])
+        )
 
         self.assertEqual(len(validate), 0)
 
-        validate = Validator().validate({
-            'date': pendulum.yesterday().to_datetime_string(),
-        }, before_today(['date']))
+        validate = Validator().validate(
+            {"date": pendulum.yesterday().to_datetime_string(),}, before_today(["date"])
+        )
 
         self.assertEqual(len(validate), 0)
 
-        validate = Validator().validate({
-            'date': '2030-05-21T22:00:00',
-        }, before_today(['date']))
+        validate = Validator().validate(
+            {"date": "2030-05-21T22:00:00",}, before_today(["date"])
+        )
 
         self.assertEqual(
-            validate.all(), {'date': ['The date must be a date before today.']})
+            validate.all(), {"date": ["The date must be a date before today."]}
+        )
 
     def test_after_today(self):
-        validate = Validator().validate({
-            'date': '2030-05-21T22:00:00',
-        }, after_today(['date']))
+        validate = Validator().validate(
+            {"date": "2030-05-21T22:00:00",}, after_today(["date"])
+        )
 
         self.assertEqual(len(validate), 0)
 
-        validate = Validator().validate({
-            'date': pendulum.tomorrow().to_datetime_string(),
-        }, after_today(['date']))
+        validate = Validator().validate(
+            {"date": pendulum.tomorrow().to_datetime_string(),}, after_today(["date"])
+        )
 
         self.assertEqual(len(validate), 0)
 
-        validate = Validator().validate({
-            'date': '1975-05-21T22:00:00',
-        }, after_today(['date']))
+        validate = Validator().validate(
+            {"date": "1975-05-21T22:00:00",}, after_today(["date"])
+        )
 
         self.assertEqual(
-            validate.all(), {'date': ['The date must be a date after today.']})
+            validate.all(), {"date": ["The date must be a date after today."]}
+        )
 
     def test_is_past(self):
-        validate = Validator().validate({
-            'date': '1950-05-21T22:00:00',
-        }, is_past(['date']))
+        validate = Validator().validate(
+            {"date": "1950-05-21T22:00:00",}, is_past(["date"])
+        )
 
         self.assertEqual(len(validate), 0)
 
-        validate = Validator().validate({
-            'date': pendulum.yesterday().to_datetime_string(),
-        }, is_past(['date'], tz='America/New_York'))
+        validate = Validator().validate(
+            {"date": pendulum.yesterday().to_datetime_string(),},
+            is_past(["date"], tz="America/New_York"),
+        )
 
         self.assertEqual(len(validate), 0)
 
-        validate = Validator().validate({
-            'date': pendulum.tomorrow().to_datetime_string(),
-        }, is_past('date', tz='America/New_York'))
+        validate = Validator().validate(
+            {"date": pendulum.tomorrow().to_datetime_string(),},
+            is_past("date", tz="America/New_York"),
+        )
 
         self.assertEqual(
-            validate.all(), {'date': ['The date must be a time in the past.']})
+            validate.all(), {"date": ["The date must be a time in the past."]}
+        )
 
     def test_is_future(self):
-        validate = Validator().validate({
-            'date': '2030-05-21T22:00:00',
-        }, is_future(['date']))
+        validate = Validator().validate(
+            {"date": "2030-05-21T22:00:00",}, is_future(["date"])
+        )
 
         self.assertEqual(len(validate), 0)
 
-        validate = Validator().validate({
-            'date': pendulum.tomorrow().to_datetime_string(),
-        }, is_future(['date'], tz='America/New_York'))
+        validate = Validator().validate(
+            {"date": pendulum.tomorrow().to_datetime_string(),},
+            is_future(["date"], tz="America/New_York"),
+        )
 
         self.assertEqual(len(validate), 0)
 
-        validate = Validator().validate({
-            'date': pendulum.yesterday().to_datetime_string(),
-        }, is_future(['date']))
+        validate = Validator().validate(
+            {"date": pendulum.yesterday().to_datetime_string(),}, is_future(["date"])
+        )
 
         self.assertEqual(
-            validate.all(), {'date': ['The date must be a time in the past.']})
+            validate.all(), {"date": ["The date must be a time in the past."]}
+        )
 
     def test_exception(self):
         with self.assertRaises(AttributeError) as e:
-            validate = Validator().validate({
-                'terms': 'on',
-            }, required(['user'], raises={
-                'user': AttributeError
-            }))
+            validate = Validator().validate(
+                {"terms": "on",}, required(["user"], raises={"user": AttributeError})
+            )
 
         try:
-            validate = Validator().validate({
-                'terms': 'on',
-            }, required(['user'], raises={
-                'user': AttributeError
-            }))
+            validate = Validator().validate(
+                {"terms": "on",}, required(["user"], raises={"user": AttributeError})
+            )
         except AttributeError as e:
-            self.assertEqual(str(e), 'The user field is required.')
+            self.assertEqual(str(e), "The user field is required.")
 
         try:
-            validate = Validator().validate({
-                'terms': 'on',
-            }, required(['user'], raises=True))
+            validate = Validator().validate(
+                {"terms": "on",}, required(["user"], raises=True)
+            )
         except ValueError as e:
-            self.assertEqual(str(e), 'The user field is required.')
+            self.assertEqual(str(e), "The user field is required.")
 
     def test_conditional(self):
-        validate = Validator().validate({
-            'terms': 'on'
-        }, when(accepted(['terms'])).then(
-            required(['user'])
-        ))
+        validate = Validator().validate(
+            {"terms": "on"}, when(accepted(["terms"])).then(required(["user"]))
+        )
 
-        self.assertEqual(validate.all(), {'user': ['The user field is required.']})
+        self.assertEqual(validate.all(), {"user": ["The user field is required."]})
 
-        validate = Validator().validate({
-            'terms': 'test'
-        }, accepted(['terms']))
+        validate = Validator().validate({"terms": "test"}, accepted(["terms"]))
 
-        self.assertEqual(
-            validate.all(), {'terms': ['The terms must be accepted.']})
+        self.assertEqual(validate.all(), {"terms": ["The terms must be accepted."]})
 
     def test_error_message_required(self):
-        validate = Validator().validate({
-            'test': 1
-        }, required(['user', 'email'], messages={
-            'user': 'there must be a user value'
-        }))
+        validate = Validator().validate(
+            {"test": 1},
+            required(
+                ["user", "email"], messages={"user": "there must be a user value"}
+            ),
+        )
 
-        self.assertEqual(validate.get('user'), ['there must be a user value'])
-        self.assertEqual(validate.get('email'), ['The email field is required.'])
+        self.assertEqual(validate.get("user"), ["there must be a user value"])
+        self.assertEqual(validate.get("email"), ["The email field is required."])
 
-        validate = Validator().validate({
-            'test': 1
-        }, required(['user', 'email'], messages={
-            'email': 'there must be an email value'
-        }))
+        validate = Validator().validate(
+            {"test": 1},
+            required(
+                ["user", "email"], messages={"email": "there must be an email value"}
+            ),
+        )
 
-        self.assertEqual(validate.get('user'), ['The user field is required.'])
-        self.assertEqual(validate.get('email'), ['there must be an email value'])
+        self.assertEqual(validate.get("user"), ["The user field is required."])
+        self.assertEqual(validate.get("email"), ["there must be an email value"])
 
     def test_numeric(self):
-        validate = Validator().validate({
-            'test': 1
-        }, numeric(['test']))
+        validate = Validator().validate({"test": 1}, numeric(["test"]))
 
         self.assertEqual(len(validate), 0)
 
-        validate = Validator().validate({
-            'test': 'hey'
-        }, numeric(['test']))
+        validate = Validator().validate({"test": "hey"}, numeric(["test"]))
 
-        self.assertEqual(validate.all(), {'test': ['The test must be a numeric.']})
+        self.assertEqual(validate.all(), {"test": ["The test must be a numeric."]})
 
     def test_several_tests(self):
-        validate = Validator().validate({
-            'test': 'hey'
-        }, required(['notin']), numeric(['notin']))
+        validate = Validator().validate(
+            {"test": "hey"}, required(["notin"]), numeric(["notin"])
+        )
 
         self.assertEqual(
-            validate.all(), {'notin': ['The notin field is required.', 'The notin must be a numeric.']})
+            validate.all(),
+            {"notin": ["The notin field is required.", "The notin must be a numeric."]},
+        )
 
     def test_json(self):
-        validate = Validator().validate({
-            'json': 'hey'
-        }, vjson(['json']))
+        validate = Validator().validate({"json": "hey"}, vjson(["json"]))
 
-        self.assertEqual(validate.all(), {'json': ['The json must be a valid JSON.']})
+        self.assertEqual(validate.all(), {"json": ["The json must be a valid JSON."]})
 
-        validate = Validator().validate({
-            'json': json.dumps({'test': 'key'})
-        }, vjson(['json']))
+        validate = Validator().validate(
+            {"json": json.dumps({"test": "key"})}, vjson(["json"])
+        )
 
         self.assertEqual(len(validate), 0)
 
     def test_length(self):
-        validate = Validator().validate({
-            'json': 'hey'
-        }, length(['json'], min=1, max=10))
+        validate = Validator().validate(
+            {"json": "hey"}, length(["json"], min=1, max=10)
+        )
 
         self.assertEqual(len(validate), 0)
 
-        validate = Validator().validate({
-            'json': 'hey'
-        }, length(['json'], '1..10'))
+        validate = Validator().validate({"json": "hey"}, length(["json"], "1..10"))
 
         self.assertEqual(len(validate), 0)
 
-        validate = Validator().validate({
-            'json': 'this is a really long string'
-        }, length(['json'], min=1, max=10))
+        validate = Validator().validate(
+            {"json": "this is a really long string"}, length(["json"], min=1, max=10)
+        )
 
         self.assertEqual(
-            validate.all(), {'json': ['The json length must be between 1 and 10.']})
+            validate.all(), {"json": ["The json length must be between 1 and 10."]}
+        )
 
         # test when only min given
-        validate = Validator().validate({
-            'json': 'hoh'
-        }, length(['json'], min=6))
+        validate = Validator().validate({"json": "hoh"}, length(["json"], min=6))
 
         self.assertEqual(
-            validate.all(), {'json': ['The json must be at least 6 characters.']})
+            validate.all(), {"json": ["The json must be at least 6 characters."]}
+        )
 
         # test when only max given
-        validate = Validator().validate({
-            'json': 'this is a string too long'
-        }, length(['json'], max=10))
+        validate = Validator().validate(
+            {"json": "this is a string too long"}, length(["json"], max=10)
+        )
 
         self.assertEqual(
-            validate.all(), {'json': ['The json length must be between 1 and 10.']})
+            validate.all(), {"json": ["The json length must be between 1 and 10."]}
+        )
 
     def test_string(self):
-        validate = Validator().validate({
-            'text': 'hey'
-        }, string(['text']))
+        validate = Validator().validate({"text": "hey"}, string(["text"]))
 
         self.assertEqual(len(validate), 0)
 
-        validate = Validator().validate({
-            'text': ['string1', 'string2']
-        }, string(['text']))
+        validate = Validator().validate(
+            {"text": ["string1", "string2"]}, string(["text"])
+        )
 
         self.assertEqual(len(validate), 0)
 
-        validate = Validator().validate({
-            'text': 1
-        }, string(['text']))
+        validate = Validator().validate({"text": 1}, string(["text"]))
 
-        self.assertEqual(validate.all(), {'text': ['The text must be a string.']})
+        self.assertEqual(validate.all(), {"text": ["The text must be a string."]})
 
     def test_none(self):
-        validate = Validator().validate({
-            'text': None
-        }, none(['text']))
+        validate = Validator().validate({"text": None}, none(["text"]))
 
         self.assertEqual(len(validate), 0)
 
-        validate = Validator().validate({
-            'text': 1
-        }, none(['text']))
+        validate = Validator().validate({"text": 1}, none(["text"]))
 
-        self.assertEqual(validate.all(), {'text': ['The text must be None.']})
+        self.assertEqual(validate.all(), {"text": ["The text must be None."]})
 
     def test_equals(self):
-        validate = Validator().validate({
-            'text': 'test1'
-        }, equals(['text'], 'test1'))
+        validate = Validator().validate({"text": "test1"}, equals(["text"], "test1"))
 
         self.assertEqual(len(validate), 0)
 
-        validate = Validator().validate({
-            'text': 'test2'
-        }, equals(['text'], 'test1'))
+        validate = Validator().validate({"text": "test2"}, equals(["text"], "test1"))
 
-        self.assertEqual(validate.all(), {'text': ['The text must be equal to test1.']})
+        self.assertEqual(validate.all(), {"text": ["The text must be equal to test1."]})
 
     def test_truthy(self):
-        validate = Validator().validate({
-            'text': 'value'
-        }, truthy(['text']))
+        validate = Validator().validate({"text": "value"}, truthy(["text"]))
 
         self.assertEqual(len(validate), 0)
 
-        validate = Validator().validate({
-            'text': 1
-        }, truthy(['text']))
+        validate = Validator().validate({"text": 1}, truthy(["text"]))
 
         self.assertEqual(len(validate), 0)
 
-        validate = Validator().validate({
-            'text': False
-        }, truthy(['text']))
+        validate = Validator().validate({"text": False}, truthy(["text"]))
 
-        self.assertEqual(validate.all(), {'text': ['The text must be a truthy value.']})
+        self.assertEqual(validate.all(), {"text": ["The text must be a truthy value."]})
 
     def test_in_range(self):
-        validate = Validator().validate({
-            'text': 52
-        }, in_range(['text'], min=25, max=72))
+        validate = Validator().validate(
+            {"text": 52}, in_range(["text"], min=25, max=72)
+        )
 
         self.assertEqual(len(validate), 0)
 
-        validate = Validator().validate({
-            'text': 101
-        }, in_range(['text'], min=25, max=72))
+        validate = Validator().validate(
+            {"text": 101}, in_range(["text"], min=25, max=72)
+        )
 
         self.assertEqual(
-            validate.all(), {'text': ['The text must be between 25 and 72.']})
+            validate.all(), {"text": ["The text must be between 25 and 72."]}
+        )
 
     def test_greater_than(self):
-        validate = Validator().validate({
-            'text': 52
-        }, greater_than(['text'], 25))
+        validate = Validator().validate({"text": 52}, greater_than(["text"], 25))
 
         self.assertEqual(len(validate), 0)
 
-        validate = Validator().validate({
-            'text': 101
-        }, greater_than(['text'], 150))
+        validate = Validator().validate({"text": 101}, greater_than(["text"], 150))
 
-        self.assertEqual(validate.all(), {'text': ['The text must be greater than 150.']})
+        self.assertEqual(
+            validate.all(), {"text": ["The text must be greater than 150."]}
+        )
 
     def test_less_than(self):
-        validate = Validator().validate({
-            'text': 10
-        }, less_than(['text'], 25))
+        validate = Validator().validate({"text": 10}, less_than(["text"], 25))
 
         self.assertEqual(len(validate), 0)
 
-        validate = Validator().validate({
-            'text': 101
-        }, less_than(['text'], 75))
+        validate = Validator().validate({"text": 101}, less_than(["text"], 75))
 
-        self.assertEqual(validate.all(), {'text': ['The text must be less than 75.']})
+        self.assertEqual(validate.all(), {"text": ["The text must be less than 75."]})
 
     def test_isnt(self):
-        validate = Validator().validate({
-            'test': 50
-        }, isnt(
-            in_range(['test'], min=10, max=20)
-        )
+        validate = Validator().validate(
+            {"test": 50}, isnt(in_range(["test"], min=10, max=20))
         )
 
         self.assertEqual(len(validate), 0)
 
-        validate = Validator().validate({
-            'test': 15
-        }, isnt(
-            in_range(['test'], min=10, max=20))
+        validate = Validator().validate(
+            {"test": 15}, isnt(in_range(["test"], min=10, max=20))
         )
 
         self.assertEqual(
-            validate.all(), {'test': ['The test must not be between 10 and 20.']})
+            validate.all(), {"test": ["The test must not be between 10 and 20."]}
+        )
 
     def test_isnt_equals(self):
-        validate = Validator().validate({
-            'test': 'test'
-        }, isnt(
-            equals(['test'], 'test'),
-            length(['test'], min=10, max=20)
-        )
+        validate = Validator().validate(
+            {"test": "test"},
+            isnt(equals(["test"], "test"), length(["test"], min=10, max=20)),
         )
 
         self.assertEqual(
-            validate.all(), {'test': ['The test must not be equal to test.']})
+            validate.all(), {"test": ["The test must not be equal to test."]}
+        )
 
     def test_contains(self):
-        validate = Validator().validate({
-            'test': 'this is a sentence'
-        }, contains(['test'], 'this'))
+        validate = Validator().validate(
+            {"test": "this is a sentence"}, contains(["test"], "this")
+        )
 
         self.assertEqual(len(validate), 0)
 
-        validate = Validator().validate({
-            'test': 'this is a not sentence'
-        }, contains(['test'], 'test'))
+        validate = Validator().validate(
+            {"test": "this is a not sentence"}, contains(["test"], "test")
+        )
 
-        self.assertEqual(validate.all(), {'test': ['The test must contain test.']})
+        self.assertEqual(validate.all(), {"test": ["The test must contain test."]})
 
     def test_is_in(self):
-        validate = Validator().validate({
-            'test': 1
-        }, is_in(['test'], [1, 2, 3]))
+        validate = Validator().validate({"test": 1}, is_in(["test"], [1, 2, 3]))
 
         self.assertEqual(len(validate), 0)
 
-        validate = Validator().validate({
-            'test': 1
-        }, is_in(['test'], [4, 2, 3]))
+        validate = Validator().validate({"test": 1}, is_in(["test"], [4, 2, 3]))
 
         self.assertEqual(
-            validate.all(), {'test': ['The test must contain an element in [4, 2, 3].']})
+            validate.all(), {"test": ["The test must contain an element in [4, 2, 3]."]}
+        )
 
     def test_when(self):
-        validate = Validator().validate({
-            'email': 'user@example.com',
-            'phone': '123-456-7890'
-        }, when(
-            isnt(
-                required('email')
-            )
-        ).then(
-            required('phone')
-        ))
+        validate = Validator().validate(
+            {"email": "user@example.com", "phone": "123-456-7890"},
+            when(isnt(required("email"))).then(required("phone")),
+        )
 
         self.assertEqual(len(validate), 0)
 
-        validate = Validator().validate({
-            'email': 'user@example.com'
-        }, when(
-            exists('email')
-        ).then(
-            required('phone')
-        ))
+        validate = Validator().validate(
+            {"email": "user@example.com"}, when(exists("email")).then(required("phone"))
+        )
 
-        self.assertEqual(validate.get('phone'), ['The phone field is required.'])
+        self.assertEqual(validate.get("phone"), ["The phone field is required."])
 
-        validate = Validator().validate({
-            'user': 'user'
-        }, when(
-            exists('email')
-        ).then(
-            required('phone')
-        ))
+        validate = Validator().validate(
+            {"user": "user"}, when(exists("email")).then(required("phone"))
+        )
 
         self.assertEqual(len(validate), 0)
 
-        validate = Validator().validate({
-            'email': 'user@example.com',
-        }, when(
-            does_not(
-                exists('email')
-            )
-        ).then(
-            required('phone')
-        ))
+        validate = Validator().validate(
+            {"email": "user@example.com",},
+            when(does_not(exists("email"))).then(required("phone")),
+        )
 
         self.assertEqual(len(validate), 0)
 
     def test_does_not(self):
-        validate = Validator().validate({
-            'phone': '123-456-7890'
-        }, does_not(
-            exists('email')
-        ).then(
-            required('phone')
-        ))
+        validate = Validator().validate(
+            {"phone": "123-456-7890"}, does_not(exists("email")).then(required("phone"))
+        )
 
         self.assertEqual(len(validate), 0)
 
-        validate = Validator().validate({
-            'email': 'user@example.com',
-            'phone': '123-456-7890'
-        }, does_not(
-            exists('email')
-        ).then(
-            required('phone')
-        ))
+        validate = Validator().validate(
+            {"email": "user@example.com", "phone": "123-456-7890"},
+            does_not(exists("email")).then(required("phone")),
+        )
 
         self.assertEqual(len(validate), 0)
 
-        validate = Validator().validate({
-            'user': 'Joe'
-        }, does_not(
-            exists('email')
-        ).then(
-            required('phone')
-        ))
+        validate = Validator().validate(
+            {"user": "Joe"}, does_not(exists("email")).then(required("phone"))
+        )
 
-        self.assertEqual(validate.get('phone'), ['The phone field is required.'])
+        self.assertEqual(validate.get("phone"), ["The phone field is required."])
 
     def test_one_of(self):
-        validate = Validator().validate({
-            'email': 'user@example.com',
-            'phone': '123-456-7890'
-        }, one_of(['email', 'phone']))
+        validate = Validator().validate(
+            {"email": "user@example.com", "phone": "123-456-7890"},
+            one_of(["email", "phone"]),
+        )
 
         self.assertEqual(len(validate), 0)
 
-        validate = Validator().validate({
-            'accepted': 'on',
-            'user': 'Joe'
-        }, one_of(['email', 'phone']))
+        validate = Validator().validate(
+            {"accepted": "on", "user": "Joe"}, one_of(["email", "phone"])
+        )
 
-        self.assertEqual(validate.get('email'), ['The email or phone is required.'])
-        self.assertEqual(validate.get('phone'), ['The email or phone is required.'])
+        self.assertEqual(validate.get("email"), ["The email or phone is required."])
+        self.assertEqual(validate.get("phone"), ["The email or phone is required."])
 
-        validate = Validator().validate({
-            'accepted': 'on',
-            'user': 'Joe'
-        }, one_of(['email', 'phone', 'password']))
+        validate = Validator().validate(
+            {"accepted": "on", "user": "Joe"}, one_of(["email", "phone", "password"])
+        )
 
-        self.assertEqual(validate.get('email'), ['The email, phone, password is required.'])
+        self.assertEqual(
+            validate.get("email"), ["The email, phone, password is required."]
+        )
 
-        validate = Validator().validate({
-            'accepted': 'on',
-            'user': 'Joe'
-        }, one_of(['email', 'phone', 'password', 'user']))
+        validate = Validator().validate(
+            {"accepted": "on", "user": "Joe"},
+            one_of(["email", "phone", "password", "user"]),
+        )
 
         self.assertEqual(len(validate), 0)
 
     def test_regex(self):
-        validate = Validator().validate({
-            'username': 'masonite_user_1',
-        }, regex(['username'], '^[a-z0-9_-]{3,16}$'))
+        validate = Validator().validate(
+            {"username": "masonite_user_1",}, regex(["username"], "^[a-z0-9_-]{3,16}$")
+        )
         self.assertEqual(len(validate), 0)
 
-        validate = Validator().validate({
-            'username': 'Masonite User 2'
-        }, regex(['username'], '^[a-z0-9_-]{3,16}$'))
-        self.assertEqual(validate.get('username'), ['The username does not match pattern ^[a-z0-9_-]{3,16}$ .'])
+        validate = Validator().validate(
+            {"username": "Masonite User 2"}, regex(["username"], "^[a-z0-9_-]{3,16}$")
+        )
+        self.assertEqual(
+            validate.get("username"),
+            ["The username does not match pattern ^[a-z0-9_-]{3,16}$ ."],
+        )
 
     def test_list_validation(self):
-        validate = Validator().validate({
-            'name': 'Joe',
-            'discounts_ref': [1,2,3]
-        },
-            required(['name', 'discounts_ref']), 
-            numeric(['discounts_ref.*']), 
+        validate = Validator().validate(
+            {"name": "Joe", "discounts_ref": [1, 2, 3]},
+            required(["name", "discounts_ref"]),
+            numeric(["discounts_ref.*"]),
         )
 
         self.assertEqual(len(validate), 0)
 
-        validate = Validator().validate({
-            'name': 'Joe',
-            'discounts_ref': [1,2,3]
-        },
-            required(['name', 'discounts_ref']), 
-            length(['discounts_ref.*'], min=1, max=2), 
+        validate = Validator().validate(
+            {"name": "Joe", "discounts_ref": [1, 2, 3]},
+            required(["name", "discounts_ref"]),
+            length(["discounts_ref.*"], min=1, max=2),
         )
 
         self.assertEqual(len(validate), 0)
 
     def test_list_validation(self):
-        validate = Validator().validate({
-            'name': 'Joe',
-            'discounts_ref': [1,2,3]
-        },
-            is_list(['discounts_ref.*']), 
+        validate = Validator().validate(
+            {"name": "Joe", "discounts_ref": [1, 2, 3]}, is_list(["discounts_ref.*"]),
         )
 
         self.assertEqual(len(validate), 0)
 
-        validate = Validator().validate({
-            'name': 'Joe',
-            'discounts_ref': {1:2}
-        },
-            is_list(['discounts_ref.*']), 
+        validate = Validator().validate(
+            {"name": "Joe", "discounts_ref": {1: 2}}, is_list(["discounts_ref.*"]),
         )
 
         self.assertEqual(len(validate), 1)
 
+    def test_file_validation(self):
+        validate = Validator().validate({"document": "a string",}, file(["document"]))
+
+        self.assertEqual(
+            validate.get("document"), ["The document is not a valid file."]
+        )
+        import os
+
+        test_file = os.path.abspath(__file__)
+        validate = Validator().validate({"document": test_file}, file(["document"]))
+        self.assertEqual(len(validate), 0)
+
+    def test_file_size_validation(self):
+        import os
+
+        test_file = os.path.abspath(__file__)
+        validate = Validator().validate(
+            {"document": test_file}, file(["document"], size=100)
+        )
+        self.assertEqual(
+            validate.get("document"), ["The document file size exceeds 100 bytes."]
+        )
+        # check that file size < 2 Mio
+        validate = Validator().validate(
+            {"document": test_file}, file(["document"], size=1024 * 1024 * 2)
+        )
+        self.assertEqual(len(validate), 0)
+
+    def test_file_mime_types_validation(self):
+        import os
+
+        test_file = os.path.abspath(__file__)
+        validate = Validator().validate(
+            {"document": test_file}, file(["document"], mimes=["jpg", "png",])
+        )
+        self.assertEqual(
+            validate.get("document"), ["The document mime type is not valid."]
+        )
+
+        validate = Validator().validate(
+            {"document": test_file}, file(["document"], mimes=["text/x-python",])
+        )
+        self.assertEqual(len(validate), 0)
+
+    def test_multiple_file_validations(self):
+        import os
+
+        test_file = os.path.abspath(__file__)
+        validate = Validator().validate(
+            {"document": test_file}, file(["document"], size=100, mimes=["jpg", "png",])
+        )
+        self.assertEqual(
+            validate.get("document"),
+            [
+                "The document file size exceeds 100 bytes.",
+                "The document mime type is not valid.",
+            ],
+        )
+
 
 class TestDotNotationValidation(unittest.TestCase):
-
     def setUp(self):
         pass
 
     def test_dot_required(self):
-        validate = Validator().validate({
-            'user': {
-                'email': 'user@example.com'
-            }
-        }, required(['user.id']))
+        validate = Validator().validate(
+            {"user": {"email": "user@example.com"}}, required(["user.id"])
+        )
 
-        self.assertEqual(validate.all(), {'user.id': ['The user.id field is required.']})
+        self.assertEqual(
+            validate.all(), {"user.id": ["The user.id field is required."]}
+        )
 
-        validate = Validator().validate({
-            'user': {
-                'id': 1
-            }
-        }, required(['user.id']))
+        validate = Validator().validate({"user": {"id": 1}}, required(["user.id"]))
 
         self.assertEqual(len(validate), 0)
 
     def test_dot_numeric(self):
-        validate = Validator().validate({
-            'user': {
-                'id': 1,
-                'email': 'user@example.com'
-            }
-        }, numeric(['user.id']))
+        validate = Validator().validate(
+            {"user": {"id": 1, "email": "user@example.com"}}, numeric(["user.id"])
+        )
 
         self.assertEqual(len(validate), 0)
 
-        validate = Validator().validate({
-            'user': {
-                'id': 1,
-                'email': 'user@example.com'
-            }
-        }, numeric(['user.email']))
+        validate = Validator().validate(
+            {"user": {"id": 1, "email": "user@example.com"}}, numeric(["user.email"])
+        )
 
         self.assertEqual(
-            validate.all(), {'user.email': ['The user.email must be a numeric.']})
+            validate.all(), {"user.email": ["The user.email must be a numeric."]}
+        )
 
     def test_dot_several_tests(self):
-        validate = Validator().validate({
-            'user': {
-                'id': 1,
-                'email': 'user@example.com'
-            }
-        }, required(['user.id', 'user.email']), numeric(['user.id']))
+        validate = Validator().validate(
+            {"user": {"id": 1, "email": "user@example.com"}},
+            required(["user.id", "user.email"]),
+            numeric(["user.id"]),
+        )
 
         self.assertEqual(len(validate), 0)
 
-        validate = Validator().validate({
-            'user': {
-                'id': 1,
-                'email': 'user@example.com'
-            }
-        }, required(['user.id', 'user.email']), numeric(['user.email']))
+        validate = Validator().validate(
+            {"user": {"id": 1, "email": "user@example.com"}},
+            required(["user.id", "user.email"]),
+            numeric(["user.email"]),
+        )
 
         self.assertEqual(
-            validate.all(), {'user.email': ['The user.email must be a numeric.']})
+            validate.all(), {"user.email": ["The user.email must be a numeric."]}
+        )
 
     def test_dot_json(self):
-        validate = Validator().validate({
-            'user': {
-                'id': 'hey',
-                'email': 'user@example.com'
-            }
-        }, vjson(['user.id']))
+        validate = Validator().validate(
+            {"user": {"id": "hey", "email": "user@example.com"}}, vjson(["user.id"])
+        )
 
-        self.assertEqual(validate.all(), {'user.id': ['The user.id must be a valid JSON.']})
+        self.assertEqual(
+            validate.all(), {"user.id": ["The user.id must be a valid JSON."]}
+        )
 
-        validate = Validator().validate({
-            'user': {
-                'id': 1,
-                'email': 'user@example.com',
-                'payload': json.dumps({'test': 'key'})
-            }
-        }, vjson(['user.payload']))
+        validate = Validator().validate(
+            {
+                "user": {
+                    "id": 1,
+                    "email": "user@example.com",
+                    "payload": json.dumps({"test": "key"}),
+                }
+            },
+            vjson(["user.payload"]),
+        )
 
         self.assertEqual(len(validate), 0)
 
     def test_dot_length(self):
-        validate = Validator().validate({
-            'user': {
-                'id': 1,
-                'email': 'user@example.com'
-            }
-        }, length(['user.id'], min=1, max=10))
+        validate = Validator().validate(
+            {"user": {"id": 1, "email": "user@example.com"}},
+            length(["user.id"], min=1, max=10),
+        )
 
         self.assertEqual(len(validate), 0)
 
-        validate = Validator().validate({
-            'user': {
-                'id': 1,
-                'email': 'user@example.com',
-                'description': 'this is a really long description'
-            }
-        }, length(['user.id'], '1..10'))
+        validate = Validator().validate(
+            {
+                "user": {
+                    "id": 1,
+                    "email": "user@example.com",
+                    "description": "this is a really long description",
+                }
+            },
+            length(["user.id"], "1..10"),
+        )
 
         self.assertEqual(len(validate), 0)
 
-        validate = Validator().validate({
-            'user': {
-                'id': 1,
-                'email': 'user@example.com',
-                'description': 'this is a really long description'
-            }
-        }, length(['user.description'], min=1, max=10))
+        validate = Validator().validate(
+            {
+                "user": {
+                    "id": 1,
+                    "email": "user@example.com",
+                    "description": "this is a really long description",
+                }
+            },
+            length(["user.description"], min=1, max=10),
+        )
 
-        self.assertEqual(validate.all(), {'user.description': [
-                         'The user.description length must be between 1 and 10.']})
+        self.assertEqual(
+            validate.all(),
+            {
+                "user.description": [
+                    "The user.description length must be between 1 and 10."
+                ]
+            },
+        )
 
     def test_dot_in_range(self):
-        validate = Validator().validate({
-            'user': {
-                'id': 1,
-                'email': 'user@example.com',
-                'age': 25
-            }
-        }, in_range(['user.age'], min=25, max=72))
+        validate = Validator().validate(
+            {"user": {"id": 1, "email": "user@example.com", "age": 25}},
+            in_range(["user.age"], min=25, max=72),
+        )
 
         self.assertEqual(len(validate), 0)
 
-        validate = Validator().validate({
-            'user': {
-                'id': 1,
-                'email': 'user@example.com',
-                'age': 25
-            }
-        }, in_range(['user.age'], min=27, max=72))
+        validate = Validator().validate(
+            {"user": {"id": 1, "email": "user@example.com", "age": 25}},
+            in_range(["user.age"], min=27, max=72),
+        )
 
         self.assertEqual(
-            validate.all(), {'user.age': ['The user.age must be between 27 and 72.']})
+            validate.all(), {"user.age": ["The user.age must be between 27 and 72."]}
+        )
 
     def test_dot_equals(self):
-        validate = Validator().validate({
-            'user': {
-                'id': 1,
-                'email': 'user@example.com',
-                'age': 25
-            }
-        }, equals(['user.age'], 25))
+        validate = Validator().validate(
+            {"user": {"id": 1, "email": "user@example.com", "age": 25}},
+            equals(["user.age"], 25),
+        )
 
         self.assertEqual(len(validate), 0)
 
-        validate = Validator().validate({
-            'user': {
-                'id': 1,
-                'email': 'user@example.com',
-                'age': 25
-            }
-        }, equals(['user.age'], 'test1'))
+        validate = Validator().validate(
+            {"user": {"id": 1, "email": "user@example.com", "age": 25}},
+            equals(["user.age"], "test1"),
+        )
 
         self.assertEqual(
-            validate.all(), {'user.age': ['The user.age must be equal to test1.']})
+            validate.all(), {"user.age": ["The user.age must be equal to test1."]}
+        )
 
     def test_can_use_asterisk(self):
-        validate = Validator().validate({
-            'user': {
-                'id': 1,
-                'addresses': [
-                    {'id': 1, 'street': 'A Street'},
-                    {'id': 2, 'street': 'B Street'},
-                    {'id': 3, 'street': 'C Street'},
-                ],
-                'age': 25
-            }
-        }, required(['user.addresses.*.id']), equals('user.addresses.*.id', [1,2,3]))
+        validate = Validator().validate(
+            {
+                "user": {
+                    "id": 1,
+                    "addresses": [
+                        {"id": 1, "street": "A Street"},
+                        {"id": 2, "street": "B Street"},
+                        {"id": 3, "street": "C Street"},
+                    ],
+                    "age": 25,
+                }
+            },
+            required(["user.addresses.*.id"]),
+            equals("user.addresses.*.id", [1, 2, 3]),
+        )
 
         self.assertEqual(len(validate), 0, validate)
 
-        validate = Validator().validate({
-            'user': {
-                'id': 1,
-                'addresses': [
-                    {'id': 1, 'street': 'A Street'},
-                    {'id': 2, 'street': 'B Street'},
-                    {'id': 3, 'street': 'C Street'},
-                ],
-                'age': 25
-            }
-        }, required(['user.addresses.*.house']))
-
-        self.assertEqual(validate.all(), {'user.addresses.*.house': ['The user.addresses.*.house field is required.']})
-
-        validate = Validator().validate({
-            'user': {
-                'id': 1,
-                'addresses': [],
-                'age': 25
-            }
-        }, required(['user.addresses.*.id']))
-
-        self.assertEqual(validate.all(), {'user.addresses.*.id': ['The user.addresses.*.id field is required.']})
-
-    def test_dot_error_message_required(self):
-        validate = Validator().validate({
-            'user': {
-                'id': 1,
-                'email': 'user@example.com',
-                'age': 25
-            }
-        }, required(['user.description'], messages={
-            'user.description': 'You are missing a description'
-        }))
-
-        self.assertEqual(validate.all(), {'user.description': [
-                         'You are missing a description']})
-
-        validate = Validator().validate({
-            'user': {
-                'id': 1,
-                'email': 'user@example.com'
-            }
-        }, required(['user.id', 'user.email', 'user.age'], messages={
-            'user.age': 'You are missing a user age'
-        }))
+        validate = Validator().validate(
+            {
+                "user": {
+                    "id": 1,
+                    "addresses": [
+                        {"id": 1, "street": "A Street"},
+                        {"id": 2, "street": "B Street"},
+                        {"id": 3, "street": "C Street"},
+                    ],
+                    "age": 25,
+                }
+            },
+            required(["user.addresses.*.house"]),
+        )
 
         self.assertEqual(
-            validate.all(), {'user.age': ['You are missing a user age']})
+            validate.all(),
+            {
+                "user.addresses.*.house": [
+                    "The user.addresses.*.house field is required."
+                ]
+            },
+        )
+
+        validate = Validator().validate(
+            {"user": {"id": 1, "addresses": [], "age": 25}},
+            required(["user.addresses.*.id"]),
+        )
+
+        self.assertEqual(
+            validate.all(),
+            {"user.addresses.*.id": ["The user.addresses.*.id field is required."]},
+        )
+
+    def test_dot_error_message_required(self):
+        validate = Validator().validate(
+            {"user": {"id": 1, "email": "user@example.com", "age": 25}},
+            required(
+                ["user.description"],
+                messages={"user.description": "You are missing a description"},
+            ),
+        )
+
+        self.assertEqual(
+            validate.all(), {"user.description": ["You are missing a description"]}
+        )
+
+        validate = Validator().validate(
+            {"user": {"id": 1, "email": "user@example.com"}},
+            required(
+                ["user.id", "user.email", "user.age"],
+                messages={"user.age": "You are missing a user age"},
+            ),
+        )
+
+        self.assertEqual(validate.all(), {"user.age": ["You are missing a user age"]})
 
 
 class TestValidationFactory(unittest.TestCase):
-
     def test_can_register(self):
         factory = ValidationFactory()
         factory.register(required)
-        self.assertEqual(factory.registry['required'], required)
+        self.assertEqual(factory.registry["required"], required)
 
 
 class TestValidationProvider(TestCase):
-
     def setUp(self):
         super().setUp()
         self.app = self.container
@@ -967,173 +959,173 @@ class TestValidationProvider(TestCase):
         self.assertTrue(self.app.make(Validator).numeric)
 
     def test_request_validation(self):
-        request = self.app.make('Request')
-        validate = self.app.make('Validator')
+        request = self.app.make("Request")
+        validate = self.app.make("Validator")
 
-        request.request_variables = {
-            'id': 1,
-            'name': 'Joe'
-        }
+        request.request_variables = {"id": 1, "name": "Joe"}
 
-        validated = request.validate(
-            validate.required(['id', 'name'])
-        )
+        validated = request.validate(validate.required(["id", "name"]))
 
         self.assertEqual(len(validated), 0)
 
-        validated = request.validate(
-            validate.required(['user'])
-        )
+        validated = request.validate(validate.required(["user"]))
 
-        self.assertEqual(validated.all(), {'user': ['The user field is required.']})
+        self.assertEqual(validated.all(), {"user": ["The user field is required."]})
 
     def test_request_validation_redirects_back_with_session(self):
         wsgi = generate_wsgi()
-        self.app.bind('Application', self.app)
-        self.app.bind('SessionCookieDriver', SessionCookieDriver)
-        self.app.bind('Environ', wsgi)
+        self.app.bind("Application", self.app)
+        self.app.bind("SessionCookieDriver", SessionCookieDriver)
+        self.app.bind("Environ", wsgi)
 
-        request = self.app.make('Request')
+        request = self.app.make("Request")
         request.load_environ(wsgi)
 
-        request.request_variables = {
-            'id': 1,
-            'name': 'Joe'
-        }
+        request.request_variables = {"id": 1, "name": "Joe"}
 
-        errors = request.validate(
-            required('user')
+        errors = request.validate(required("user"))
+
+        request.session = SessionManager(self.app).driver("cookie")
+        request.key("UKLAdrye6pZG4psVRPZytukJo2-A_Zxbo0VaqR5oig8=")
+        self.assertEqual(
+            request.redirect("/login").with_errors(errors).redirect_url, "/login"
+        )
+        self.assertEqual(
+            request.redirect("/login").with_errors(errors).session.get("errors"),
+            {"user": ["The user field is required."]},
         )
 
-        request.session = SessionManager(self.app).driver('cookie')
-        request.key('UKLAdrye6pZG4psVRPZytukJo2-A_Zxbo0VaqR5oig8=')
-        self.assertEqual(request.redirect(
-            '/login').with_errors(errors).redirect_url, '/login')
-        self.assertEqual(request.redirect(
-            '/login').with_errors(errors).session.get('errors'), {'user': ['The user field is required.']})
-
     def test_confirmed(self):
-        validate = Validator().validate({
-            'password': 'secret',
-            'password_confirmation': 'secret',
-        }, confirmed(['password']))
+        validate = Validator().validate(
+            {"password": "secret", "password_confirmation": "secret",},
+            confirmed(["password"]),
+        )
 
         self.assertEqual(len(validate), 0)
 
-        validate = Validator().validate({
-            'password': 'secret',
-        }, confirmed(['password']))
+        validate = Validator().validate(
+            {"password": "secret",}, confirmed(["password"])
+        )
 
         self.assertEqual(
-            validate.all(), {'password': ['The password confirmation does not match.']})
+            validate.all(), {"password": ["The password confirmation does not match."]}
+        )
 
-        validate = Validator().validate({
-        }, confirmed(['password']))
-
-        self.assertEqual(
-            validate.all(), {'password': ['The password confirmation does not match.']})
-
-        validate = Validator().validate({
-            'password': 'secret',
-            'password_confirmation': 'foo',
-        }, confirmed(['password']))
+        validate = Validator().validate({}, confirmed(["password"]))
 
         self.assertEqual(
-            validate.all(), {'password': ['The password confirmation does not match.']})
+            validate.all(), {"password": ["The password confirmation does not match."]}
+        )
+
+        validate = Validator().validate(
+            {"password": "secret", "password_confirmation": "foo",},
+            confirmed(["password"]),
+        )
+
+        self.assertEqual(
+            validate.all(), {"password": ["The password confirmation does not match."]}
+        )
 
     def test_strong(self):
-        validate = Validator().validate({
-            'password': 'secret',
-        }, strong(['password'], uppercase=0, special=0, numbers=0))
+        validate = Validator().validate(
+            {"password": "secret",},
+            strong(["password"], uppercase=0, special=0, numbers=0),
+        )
 
         self.assertEqual(
-            validate.all(), {'password': ['The password field must be 8 characters in length']})
-        
-        validate = Validator().validate({
-            'password': 'Secret',
-        }, strong(['password'], length=5, uppercase=2, special=0, numbers=0))
+            validate.all(),
+            {"password": ["The password field must be 8 characters in length"]},
+        )
+
+        validate = Validator().validate(
+            {"password": "Secret",},
+            strong(["password"], length=5, uppercase=2, special=0, numbers=0),
+        )
 
         self.assertEqual(
-            validate.all(), {'password': ['The password field must have 2 uppercase letters']})
+            validate.all(),
+            {"password": ["The password field must have 2 uppercase letters"]},
+        )
 
-        validate = Validator().validate({
-            'password': 'secret!',
-        }, strong(['password'], length=5, uppercase=0, special=2, numbers=0))
-
-        self.assertEqual(
-            validate.all(), {'password': ['The password field must have 2 special characters']})
-
-        validate = Validator().validate({
-            'password': 'secret!',
-        }, strong(['password'], length=5, uppercase=0, special=0, numbers=2))
+        validate = Validator().validate(
+            {"password": "secret!",},
+            strong(["password"], length=5, uppercase=0, special=2, numbers=0),
+        )
 
         self.assertEqual(
-            validate.all(), {'password': ['The password field must have 2 numbers']})
+            validate.all(),
+            {"password": ["The password field must have 2 special characters"]},
+        )
 
-        validate = Validator().validate({
-            'password': 'secret!',
-        }, strong(['password'], length=8, uppercase=2, special=2, numbers=2))
+        validate = Validator().validate(
+            {"password": "secret!",},
+            strong(["password"], length=5, uppercase=0, special=0, numbers=2),
+        )
 
-        password_validation = validate.get('password')
-        self.assertIn('The password field must have 2 numbers', password_validation)
-        self.assertIn('The password field must be 8 characters in length',
-                      password_validation)
-        self.assertIn('The password field must have 2 uppercase letters',
-                      password_validation)
-        self.assertIn('The password field must have 2 special characters',
-                      password_validation)
+        self.assertEqual(
+            validate.all(), {"password": ["The password field must have 2 numbers"]}
+        )
+
+        validate = Validator().validate(
+            {"password": "secret!",},
+            strong(["password"], length=8, uppercase=2, special=2, numbers=2),
+        )
+
+        password_validation = validate.get("password")
+        self.assertIn("The password field must have 2 numbers", password_validation)
+        self.assertIn(
+            "The password field must be 8 characters in length", password_validation
+        )
+        self.assertIn(
+            "The password field must have 2 uppercase letters", password_validation
+        )
+        self.assertIn(
+            "The password field must have 2 special characters", password_validation
+        )
 
     def test_strong_breach(self):
-        validate = Validator().validate({
-            'password': 'secret',
-        }, strong(['password'], breach=True))
+        validate = Validator().validate(
+            {"password": "secret",}, strong(["password"], breach=True)
+        )
 
-        password_validation = validate.get('password')
-        self.assertIn('The password field has been breached in the past. Try another password', password_validation)
-        
+        password_validation = validate.get("password")
+        self.assertIn(
+            "The password field has been breached in the past. Try another password",
+            password_validation,
+        )
+
 
 class MockRuleEnclosure(RuleEnclosure):
-
     def rules(self):
-        return [
-            required(['username', 'email']),
-            accepted('terms')
-        ]
+        return [required(["username", "email"]), accepted("terms")]
 
 
 class TestRuleEnclosure(unittest.TestCase):
-
     def test_enclosure_can_encapsulate_rules(self):
-        validate = Validator().validate({
-            'username': 'user123',
-            'email': 'user@example.com',
-            'terms': 'on'
-        }, MockRuleEnclosure)
+        validate = Validator().validate(
+            {"username": "user123", "email": "user@example.com", "terms": "on"},
+            MockRuleEnclosure,
+        )
 
         self.assertEqual(len(validate), 0)
 
-        validate = Validator().validate({
-            'email': 'user@example.com',
-            'terms': 'on'
-        }, MockRuleEnclosure)
+        validate = Validator().validate(
+            {"email": "user@example.com", "terms": "on"}, MockRuleEnclosure
+        )
 
         self.assertEqual(len(validate), 1)
 
+
 class TestDictValidation(unittest.TestCase):
-
-
-
     def test_dictionary(self):
-        validate = Validator().validate({
-            'test': 1,
-            'terms': 'on',
-            'name': 'Joe',
-            'age': '25'
-        }, {
-            'test': 'required|truthy',
-            'terms': 'accepted',
-            'name': 'required|equals:Joe',
-            'age': 'required|greater_than:18'
-        })
+        validate = Validator().validate(
+            {"test": 1, "terms": "on", "name": "Joe", "age": "25"},
+            {
+                "test": "required|truthy",
+                "terms": "accepted",
+                "name": "required|equals:Joe",
+                "age": "required|greater_than:18",
+            },
+        )
 
         self.assertEqual(len(validate), 0)


### PR DESCRIPTION
- [x] Add negated message 
- [x] Add better parsing of input size (don't use bytes) => found a nice package to do that 💪 
```
>>> FileSize('1k')
... 1000
>>> FileSize('1K')
... 1024
>>> FileSize('1kib')
... 1024
>>> FileSize('1K', default_binary=False, case_sensitive=False)
... 1000
>>> FileSize('1 kibibyte')
... 1024
```
So we can for example use it like this : `file(["document"], size="15MB")` !

- [x] Find a way to define MIME types, currently the default module in Python 3 is using the official MIME types (as defined here https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types). But it might be difficult for user to define the rule with those mime types, it's easier for him to just give a list of extensions.

- [x] Finally I would like to add (as proposed) some meta rules (which are rules) but higher levels such as `image` or `video`.

```python
image(['avatar'], size='600KB')
video(['document'], size='15M')
```