### PR TITLE
Add rules: different, uuid, distinct, required_if, required_with

### DIFF
--- a/src/masonite/validation/Validator.py
+++ b/src/masonite/validation/Validator.py
@@ -1030,6 +1030,7 @@ class postal_code(BaseValidation):
 
 
 class different(BaseValidation):
+    """The field under validation must be different than an other given field."""
     def __init__(self, validations, other_field, messages={}, raises={}):
         super().__init__(validations, messages=messages, raises=raises)
         self.other_field = other_field
@@ -1046,6 +1047,8 @@ class different(BaseValidation):
 
 
 class uuid(BaseValidation):
+    """The field under validation must be a valid UUID. The UUID version standard
+    can be precised (1,3,4,5)."""
     def __init__(self, validations, version=None, messages={}, raises={}):
         super().__init__(validations, messages=messages, raises=raises)
         self.version = version
@@ -1072,7 +1075,7 @@ class uuid(BaseValidation):
 
 
 class required_if(BaseValidation):
-    """The field under validation must be present and not empty only 
+    """The field under validation must be present and not empty only
     if an other field has a given value."""
     def __init__(self, validations, other_field, value, messages={}, raises={}):
         super().__init__(validations, messages=messages, raises=raises)
@@ -1095,7 +1098,7 @@ class required_if(BaseValidation):
 
 
 class required_with(BaseValidation):
-    """The field under validation must be present and not empty only 
+    """The field under validation must be present and not empty only
     if any of the other specified fields are present."""
 
     def __init__(self, validations, other_fields, messages={}, raises={}):

--- a/src/masonite/validation/Validator.py
+++ b/src/masonite/validation/Validator.py
@@ -1029,6 +1029,22 @@ class postal_code(BaseValidation):
         return "The {} is a valid {} postal code.".format(attribute, self.locale)
 
 
+class different(BaseValidation):
+    def __init__(self, validations, other_field, messages={}, raises={}):
+        super().__init__(validations, messages=messages, raises=raises)
+        self.other_field = other_field
+
+    def passes(self, attribute, key, dictionary):
+        other_value = dictionary.get(self.other_field, None)
+        return attribute != other_value
+
+    def message(self, attribute):
+        return "The {} value must be different than {} value.".format(attribute, self.other_field)
+
+    def negated_message(self, attribute):
+        return "The {} value be the same as {} value.".format(attribute, self.other_field)
+
+
 def flatten(iterable):
 
     flat_list = []
@@ -1139,6 +1155,7 @@ class ValidationFactory:
             contains,
             date,
             does_not,
+            different,
             equals,
             email,
             exists,

--- a/src/masonite/validation/Validator.py
+++ b/src/masonite/validation/Validator.py
@@ -1049,7 +1049,7 @@ class different(BaseValidation):
 class uuid(BaseValidation):
     """The field under validation must be a valid UUID. The UUID version standard
     can be precised (1,3,4,5)."""
-    def __init__(self, validations, version=None, messages={}, raises={}):
+    def __init__(self, validations, version=4, messages={}, raises={}):
         super().__init__(validations, messages=messages, raises=raises)
         self.version = version
         self.uuid_type = "UUID"
@@ -1060,10 +1060,7 @@ class uuid(BaseValidation):
         from uuid import UUID
         try:
             uuid_value = UUID(str(attribute))
-            if self.version:
-                return uuid_value.version == int(self.version)
-            else:
-                return True
+            return uuid_value.version == int(self.version)
         except ValueError:
             return False
 
@@ -1139,10 +1136,7 @@ class distinct(BaseValidation):
 
     def passes(self, attribute, key, dictionary):
         # check if list contains duplicates
-        if len(set(attribute)) != len(attribute):
-            return False
-        else:
-            return True
+        return len(set(attribute)) == len(attribute)
 
     def message(self, attribute):
         return "The {} field has duplicate values.".format(attribute)

--- a/src/masonite/validation/Validator.py
+++ b/src/masonite/validation/Validator.py
@@ -1082,8 +1082,8 @@ class required_if(BaseValidation):
     def passes(self, attribute, key, dictionary):
         if dictionary.get(self.other_field, None) == self.value:
             return required.passes(self, attribute, key, dictionary)
-        else:
-            return True
+
+        return True
 
     def message(self, attribute):
         return "The {} is required because {}={}.".format(attribute, self.other_field, self.value)

--- a/src/masonite/validation/Validator.py
+++ b/src/masonite/validation/Validator.py
@@ -96,7 +96,8 @@ class required(BaseValidation):
         Returns:
             bool
         """
-        return attribute or key in dictionary
+        # return attribute or key in dictionary
+        return key in dictionary and attribute
 
     def message(self, key):
         """A message to show when this rule fails
@@ -1071,6 +1072,30 @@ class uuid(BaseValidation):
         return "The {} value must not be a valid {}.".format(attribute, self.uuid_type)
 
 
+class required_if(BaseValidation):
+
+    def __init__(self, validations, other_field, value, messages={}, raises={}):
+        super().__init__(validations, messages=messages, raises=raises)
+        self.other_field = other_field
+        self.value = value
+
+    def passes(self, attribute, key, dictionary):
+        if dictionary.get(self.other_field, None) == self.value:
+            import pdb
+            pdb.set_trace()
+            return required.passes(self, attribute, key, dictionary)
+        else:
+            return True
+
+    def message(self, attribute):
+        return "The {} is required because {}={}.".format(attribute, self.other_field, self.value)
+
+    def negated_message(self, attribute):
+        return "The {} is not required because {}={} or {} is not present.".format(
+            attribute, self.other_field, self.value, self.other_field
+        )
+
+
 def flatten(iterable):
 
     flat_list = []
@@ -1206,6 +1231,7 @@ class ValidationFactory:
             postal_code,
             regex,
             required,
+            required_if,
             string,
             strong,
             timezone,

--- a/src/masonite/validation/Validator.py
+++ b/src/masonite/validation/Validator.py
@@ -85,19 +85,18 @@ class required(BaseValidation):
     def passes(self, attribute, key, dictionary):
         """The passing criteria for this rule.
 
-        This should return a True boolean value.
+        The key must exist in the dictionary and return a True boolean value.
+        The key can use * notation.
 
         Arguments:
             attribute {mixed} -- The value found within the dictionary
             key {string} -- The key in the dictionary being searched for.
-                            This key may or may not exist in the dictionary.
             dictionary {dict} -- The dictionary being searched
 
         Returns:
             bool
         """
-        # return attribute or key in dictionary
-        return key in dictionary and attribute
+        return self.find(key, dictionary) and attribute
 
     def message(self, key):
         """A message to show when this rule fails
@@ -1073,7 +1072,8 @@ class uuid(BaseValidation):
 
 
 class required_if(BaseValidation):
-
+    """The field under validation must be present and not empty only 
+    if an other field has a given value."""
     def __init__(self, validations, other_field, value, messages={}, raises={}):
         super().__init__(validations, messages=messages, raises=raises)
         self.other_field = other_field

--- a/src/masonite/validation/Validator.py
+++ b/src/masonite/validation/Validator.py
@@ -1045,6 +1045,32 @@ class different(BaseValidation):
         return "The {} value be the same as {} value.".format(attribute, self.other_field)
 
 
+class uuid(BaseValidation):
+    def __init__(self, validations, version=None, messages={}, raises={}):
+        super().__init__(validations, messages=messages, raises=raises)
+        self.version = version
+        self.uuid_type = "UUID"
+        if version:
+            self.uuid_type = "UUID {0}".format(self.version)
+
+    def passes(self, attribute, key, dictionary):
+        from uuid import UUID
+        try:
+            uuid_value = UUID(str(attribute))
+            if self.version:
+                return uuid_value.version == int(self.version)
+            else:
+                return True
+        except ValueError:
+            return False
+
+    def message(self, attribute):
+        return "The {} value must be a valid {}.".format(attribute, self.uuid_type)
+
+    def negated_message(self, attribute):
+        return "The {} value must not be a valid {}.".format(attribute, self.uuid_type)
+
+
 def flatten(iterable):
 
     flat_list = []
@@ -1184,6 +1210,7 @@ class ValidationFactory:
             strong,
             timezone,
             truthy,
+            uuid,
             video,
             when,
         )

--- a/src/masonite/validation/Validator.py
+++ b/src/masonite/validation/Validator.py
@@ -1133,6 +1133,24 @@ class required_with(BaseValidation):
         )
 
 
+class distinct(BaseValidation):
+    """When working with list, the field under validation must not have any
+    duplicate values."""
+
+    def passes(self, attribute, key, dictionary):
+        # check if list contains duplicates
+        if len(set(attribute)) != len(attribute):
+            return False
+        else:
+            return True
+
+    def message(self, attribute):
+        return "The {} field has duplicate values.".format(attribute)
+
+    def negated_message(self, attribute):
+        return "The {} field has only different values.".format(attribute)
+
+
 def flatten(iterable):
 
     flat_list = []
@@ -1244,6 +1262,7 @@ class ValidationFactory:
             date,
             does_not,
             different,
+            distinct,
             equals,
             email,
             exists,

--- a/src/masonite/validation/__init__.py
+++ b/src/masonite/validation/__init__.py
@@ -12,6 +12,7 @@ from .Validator import (
     contains,
     date,
     different,
+    distinct,
     does_not,
     email,
     equals,

--- a/src/masonite/validation/__init__.py
+++ b/src/masonite/validation/__init__.py
@@ -11,6 +11,7 @@ from .Validator import (
     confirmed,
     contains,
     date,
+    different,
     does_not,
     email,
     equals,

--- a/src/masonite/validation/__init__.py
+++ b/src/masonite/validation/__init__.py
@@ -39,6 +39,7 @@ from .Validator import (
     strong,
     timezone,
     truthy,
+    uuid,
     video,
     when,
 )

--- a/src/masonite/validation/__init__.py
+++ b/src/masonite/validation/__init__.py
@@ -36,6 +36,7 @@ from .Validator import (
     regex,
     required,
     required_if,
+    required_with,
     string,
     strong,
     timezone,

--- a/src/masonite/validation/__init__.py
+++ b/src/masonite/validation/__init__.py
@@ -35,6 +35,7 @@ from .Validator import (
     postal_code,
     regex,
     required,
+    required_if,
     string,
     strong,
     timezone,

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -894,15 +894,22 @@ class TestValidation(unittest.TestCase):
             validate.get("field_1"), ["The field_1 value must be different than field_2 value."]
         )
 
-    def test_all_uuid_versions_are_considered_valid(self):
+    def test_that_default_uuid_must_be_uuid4(self):
         from uuid import NAMESPACE_DNS
         u3 = uuid3(NAMESPACE_DNS, "domain.com")
         u5 = uuid5(NAMESPACE_DNS, "domain.com")
-        for uuid_value in [uuid1(), u3, uuid4(), u5]:
+        for uuid_value in [uuid1(), u3, u5]:
             validate = Validator().validate({
                 "document_id": uuid_value,
             }, uuid(["document_id"]))
-            self.assertEqual(len(validate), 0)
+            self.assertEqual(
+                validate.get("document_id"), ["The document_id value must be a valid UUID 4."]
+            )
+
+        validate = Validator().validate({
+            "document_id": uuid4(),
+        }, uuid(["document_id"], 4))
+        self.assertEqual(len(validate), 0)
 
     def test_invalid_uuid_values(self):
         for uuid_value in [None, [], True, "", "uuid", {"uuid": "nope"}, 3, ()]:
@@ -910,7 +917,7 @@ class TestValidation(unittest.TestCase):
                 "document_id": uuid_value,
             }, uuid(["document_id"]))
             self.assertEqual(
-                validate.get("document_id"), ["The document_id value must be a valid UUID."]
+                validate.get("document_id"), ["The document_id value must be a valid UUID 4."]
             )
 
     def test_uuid_rule_with_specified_versions(self):

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -74,6 +74,11 @@ class TestValidation(unittest.TestCase):
 
         self.assertEqual(len(validate), 0)
 
+    def test_required_with_non_truthy_values(self):
+        for falsy_value in [[], {}, "", False, 0]:
+            validate = Validator().validate({"user": falsy_value}, required(["user"]))
+            self.assertEqual(validate.get("user"), ["The user field is required."])
+
     def test_can_validate_null_values(self):
         validate = Validator().validate({"test": None}, length(["test"], min=2, max=5))
 

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -20,6 +20,7 @@ from src.masonite.validation import (
     confirmed,
     contains,
     date,
+    different,
     does_not,
     email,
     equals,
@@ -859,6 +860,29 @@ class TestValidation(unittest.TestCase):
             )
 
         self.assertEqual(len(validate), 0)
+
+    def test_different(self):
+        validate = Validator().validate({
+            "field_1": "value_1",
+            "field_2": "value_2"
+        }, different(["field_1"], "field_2"))
+        self.assertEqual(len(validate), 0)
+
+        validate = Validator().validate({
+            "field_1": "value_1",
+            "field_2": "value_1"
+        }, different(["field_1"], "field_2"))
+        self.assertEqual(
+            validate.get("field_1"), ["The field_1 value must be different than field_2 value."]
+        )
+
+        validate = Validator().validate({
+            "field_1": None,
+            "field_2": None
+        }, different(["field_1"], "field_2"))
+        self.assertEqual(
+            validate.get("field_1"), ["The field_1 value must be different than field_2 value."]
+        )
 
 
 class TestDotNotationValidation(unittest.TestCase):

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -22,6 +22,7 @@ from src.masonite.validation import (
     contains,
     date,
     different,
+    distinct,
     does_not,
     email,
     equals,
@@ -1015,6 +1016,44 @@ class TestValidation(unittest.TestCase):
         }, required_with(["email"], "first_name,nick_name"))
         self.assertEqual(
             validate.get("email"), ["The email is required because one in first_name,nick_name is present."]
+        )
+
+    def test_distinct(self):
+        validate = Validator().validate({
+            "users": [
+                {
+                    "first_name": "John",
+                    "last_name": "Masonite",
+                },
+                {
+                    "first_name": "Joe",
+                    "last_name": "Masonite",
+                }
+            ]
+        }, distinct(["users.*.last_name"]))
+        self.assertEqual(
+            validate.get("users.*.last_name"), ["The users.*.last_name field has duplicate values."]
+        )
+        validate = Validator().validate({
+            "users": [
+                {
+                    "id": 1,
+                    "name": "John",
+                },
+                {
+                    "id": 2,
+                    "name": "Nick",
+                }
+            ]
+        }, distinct(["users.*.id"]))
+        self.assertEqual(len(validate), 0)
+
+    def test_distinct_with_simple_list(self):
+        validate = Validator().validate({
+            "emails": ["john@masonite.com", "joe@masonite.com", "john@masonite.com"]
+        }, distinct(["emails"]))
+        self.assertEqual(
+            validate.get("emails"), ["The emails field has duplicate values."]
         )
 
 

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -52,6 +52,7 @@ from src.masonite.validation.Validator import (
     one_of,
     phone,
     required,
+    required_if,
     string,
     timezone,
     truthy,
@@ -938,6 +939,37 @@ class TestValidation(unittest.TestCase):
             self.assertEqual(
                 validate.get("document_id"), ["The document_id value must be a valid UUID 3."]
             )
+
+    def test_required_if_rule_when_other_field_is_present(self):
+        validate = Validator().validate({
+            "first_name": "Sam",
+            "last_name": "Gamji"
+        }, required_if(["last_name"], "first_name", "Sam")) 
+        self.assertEqual(len(validate), 0)
+        validate = Validator().validate({
+            "first_name": "Sam",
+            "last_name": ""
+        }, required_if(["last_name"], "first_name", "Sam")) 
+        self.assertEqual(
+            validate.get("last_name"), ["The last_name is required because first_name=Sam."]
+        )
+        validate = Validator().validate({
+            "first_name": "Sam",
+            "last_name": ""
+        }, required_if(["last_name"], "first_name", "Joe")) 
+        self.assertEqual(len(validate), 0)
+
+    def test_required_if_rule_when_other_field_is_not_present(self):
+        validate = Validator().validate({
+            "first_name": "Sam",
+        }, required_if(["last_name"], "first_name", "Sam")) 
+        self.assertEqual(
+            validate.get("last_name"), ["The last_name is required because first_name=Sam."]
+        )
+        validate = Validator().validate({
+            "first_name": "Sam",
+        }, required_if(["last_name"], "first_name", "Joe")) 
+        self.assertEqual(len(validate), 0)
 
 
 class TestDotNotationValidation(unittest.TestCase):

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -904,7 +904,7 @@ class TestValidation(unittest.TestCase):
             }, uuid(["document_id"]))
             self.assertEqual(len(validate), 0)
 
-    def test_unvalid_uuid_values(self):
+    def test_invalid_uuid_values(self):
         for uuid_value in [None, [], True, "", "uuid", {"uuid": "nope"}, 3, ()]:
             validate = Validator().validate({
                 "document_id": uuid_value,
@@ -951,31 +951,31 @@ class TestValidation(unittest.TestCase):
         validate = Validator().validate({
             "first_name": "Sam",
             "last_name": "Gamji"
-        }, required_if(["last_name"], "first_name", "Sam")) 
+        }, required_if(["last_name"], "first_name", "Sam"))
         self.assertEqual(len(validate), 0)
         validate = Validator().validate({
             "first_name": "Sam",
             "last_name": ""
-        }, required_if(["last_name"], "first_name", "Sam")) 
+        }, required_if(["last_name"], "first_name", "Sam"))
         self.assertEqual(
             validate.get("last_name"), ["The last_name is required because first_name=Sam."]
         )
         validate = Validator().validate({
             "first_name": "Sam",
             "last_name": ""
-        }, required_if(["last_name"], "first_name", "Joe")) 
+        }, required_if(["last_name"], "first_name", "Joe"))
         self.assertEqual(len(validate), 0)
 
     def test_required_if_rule_when_other_field_is_not_present(self):
         validate = Validator().validate({
             "first_name": "Sam",
-        }, required_if(["last_name"], "first_name", "Sam")) 
+        }, required_if(["last_name"], "first_name", "Sam"))
         self.assertEqual(
             validate.get("last_name"), ["The last_name is required because first_name=Sam."]
         )
         validate = Validator().validate({
             "first_name": "Sam",
-        }, required_if(["last_name"], "first_name", "Joe")) 
+        }, required_if(["last_name"], "first_name", "Joe"))
         self.assertEqual(len(validate), 0)
 
     def test_required_with_rule(self):
@@ -983,17 +983,17 @@ class TestValidation(unittest.TestCase):
             "first_name": "Sam",
             "last_name": "Gamji",
             "email": "samgamji@loftr.com"
-        }, required_with(["email"], ["first_name", "last_name" "nick_name"])) 
+        }, required_with(["email"], ["first_name", "last_name" "nick_name"]))
         self.assertEqual(len(validate), 0)
         validate = Validator().validate({
             "first_name": "Sam",
             "email": "samgamji@loftr.com"
-        }, required_with(["email"], "first_name")) 
+        }, required_with(["email"], "first_name"))
         self.assertEqual(len(validate), 0)
         validate = Validator().validate({
             "first_name": "Sam",
             "email": ""
-        }, required_with(["email"], "first_name")) 
+        }, required_with(["email"], "first_name"))
         self.assertEqual(
             validate.get("email"), ["The email is required because first_name is present."]
         )


### PR DESCRIPTION
* Add `different` rule (more handy than doing `isnt(equals("field"))`)
```python
{
  "first_name": "Sam",
  "last_name": "Gamji"
}
validate.different("first_name", "last_name")
```

* Add `uuid` rule
```python
{
  "doc_id": "c1d38bb1-139e-4099-8a20-61a2a0c9b996"
}
validate.uuid("doc_id")
validate.uuid("doc_id", 4)
validate.uuid("doc_id", "4")
validate.uuid("doc_id", version=4)
```
* Edit `required` rule (check #45)
* Add `distinct` rule
```python
{
  "users": ["sam", "joe", "joe"]
}
validate.distinct("users"). # fail
{
  "users": [
       {
            "id": 1,
            "name": "joe"
       },
       {
            "id": 1,
            "name": "sam"
       },
  ]
}
validate.distinct("users.*.id"). # fail
```

* Add `required_if` rule
> The field under validation must be present and not empty only 
    if an other field has a given value.
```python
{
  "first_name": "Sam",
  "last_name": "Gamji"
}
validate.required_if("first_name", "last_name", "Gamji")
```

* Add `required_with` rule
> The field under validation must be present and not empty only 
    if any of the other specified fields are present.
```python
{
  "first_name": "Sam",
  "last_name": "Gamji",
  "email": "samgamji@lotr.com"
}
validate.required_with("email", ["first_name", "nick_name"])
validate.required_with("email", "first_name,nick_name")
```