### PR TITLE
Fix/48

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ pytest
 flake8
 pwnedapi==1.0.2
 hfilesize==0.1.0
+masonite-dot==0.0.5

--- a/src/masonite/validation/Validator.py
+++ b/src/masonite/validation/Validator.py
@@ -463,12 +463,12 @@ class in_range(BaseValidation):
         if "." in attribute:
             try:
                 attribute = float(attribute)
-            except:
+            except Exception:
                 pass
 
         elif attribute.isdigit():
             attribute = int(attribute)
-        
+
         return attribute >= self.min and attribute <= self.max
 
     def message(self, attribute):

--- a/src/masonite/validation/Validator.py
+++ b/src/masonite/validation/Validator.py
@@ -458,13 +458,13 @@ class in_range(BaseValidation):
         attribute = str(attribute)
 
         if attribute.isalpha():
-            raise ValueError("In range rule only accepts numeric values.")
+            return False
 
         if "." in attribute:
             try:
-              attribute = float(attribute)
+                attribute = float(attribute)
             except:
-              pass
+                pass
 
         elif attribute.isdigit():
             attribute = int(attribute)

--- a/src/masonite/validation/Validator.py
+++ b/src/masonite/validation/Validator.py
@@ -454,6 +454,21 @@ class in_range(BaseValidation):
         self.max = max
 
     def passes(self, attribute, key, dictionary):
+
+        attribute = str(attribute)
+
+        if attribute.isalpha():
+            raise ValueError("In range rule only accepts numeric values.")
+
+        if "." in attribute:
+            try:
+              attribute = float(attribute)
+            except:
+              pass
+
+        elif attribute.isdigit():
+            attribute = int(attribute)
+        
         return attribute >= self.min and attribute <= self.max
 
     def message(self, attribute):

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -459,6 +459,18 @@ class TestValidation(unittest.TestCase):
         self.assertEqual(len(validate), 0)
 
         validate = Validator().validate(
+            {"text": "1"}, in_range(["text"], min=1, max=10)
+        )
+
+        self.assertEqual(len(validate), 0)
+
+        validate = Validator().validate(
+            {"text": "1.5"}, in_range(["text"], min=1.5, max=5.5)
+        )
+
+        self.assertEqual(len(validate), 0)
+
+        validate = Validator().validate(
             {"text": 101}, in_range(["text"], min=25, max=72)
         )
 
@@ -990,6 +1002,15 @@ class TestDotNotationValidation(unittest.TestCase):
 
         self.assertEqual(
             validate.all(), {"user.age": ["The user.age must be between 27 and 72."]}
+        )
+
+        validate = Validator().validate(
+            {"data": {"value": "1.5"}},
+            in_range(["data.value"], min=2, max=2.5),
+        )
+
+        self.assertEqual(
+            validate.all(), {"data.value": ["The data.value must be between 2 and 2.5."]}
         )
 
     def test_dot_equals(self):

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -465,6 +465,18 @@ class TestValidation(unittest.TestCase):
         self.assertEqual(len(validate), 0)
 
         validate = Validator().validate(
+            {"text": 1}, in_range(["text"], min=1, max=10)
+        )
+
+        self.assertEqual(len(validate), 0)
+
+        validate = Validator().validate(
+            {"text": "hello"}, in_range(["text"], min=1, max=10)
+        )
+
+        self.assertEqual(validate.get("text"), ["The text must be between 1 and 10."])
+
+        validate = Validator().validate(
             {"text": "1.5"}, in_range(["text"], min=1.5, max=5.5)
         )
 


### PR DESCRIPTION
@josephmancuso Closes #48 

Adding support to implicit convertion from str to numeric to handle verification of the in_range rule.

- [x] Verification of numbers as strings
- [x] Verification of numbers as float
- [ ] Add in doc the support for type float in_range rule

What happens if the user passes some like "a" in in_range() rule? raise the negated_message or exception to only accept numeric types?