### PR TITLE
Fix standalone usage

### DIFF
--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -7,32 +7,31 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-          python-version: [ '3.5', '3.6', '3.7', '3.8' ]
+        python-version: ["3.6", "3.7", "3.8", "3.9"]
     name: Python ${{ matrix.python-version }}
     steps:
-    - uses: actions/checkout@v1
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
-      with:
+      - uses: actions/checkout@v1
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v1
+        with:
           python-version: ${{ matrix.python-version }}
-    - name: Install dependencies
-      run: |
-        make init
-    - name: Test with pytest
-      run: |
-        make test
+      - name: Install dependencies
+        run: |
+          make init
+      - name: Test with pytest
+        run: |
+          make test
   lint:
     runs-on: ubuntu-latest
     name: Lint
     steps:
-    - uses: actions/checkout@v1
-    - name: Set up Python 3.6
-      uses: actions/setup-python@v1
-      with:
-        python-version: 3.6
-    - name: Intall Flake8
-      run: |
-        pip install flake8
-    - name: Lint
-      run: make lint
-
+      - uses: actions/checkout@v1
+      - name: Set up Python 3.6
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.6
+      - name: Intall Flake8
+        run: |
+          pip install flake8
+      - name: Lint
+        run: make lint

--- a/app/User.py
+++ b/app/User.py
@@ -1,10 +1,10 @@
 """ User Model """
 
-from config.database import Model
+from masoniteorm.models import Model
 
 
 class User(Model):
-    """User Model 
+    """User Model
     """
 
     __fillable__ = ['name', 'email', 'password']

--- a/config/application.py
+++ b/config/application.py
@@ -80,12 +80,10 @@ STATIC_ROOT = os.path.join(BASE_DIRECTORY, 'storage')
 | Autoload Directories
 |--------------------------------------------------------------------------
 |
-| List of directories that are used to find classes and autoload them into 
+| List of directories that are used to find classes and autoload them into
 | the Service Container. This is initially used to find models and load
 | them in but feel free to autoload any directories
 |
 """
 
-AUTOLOAD = [
-    'app',
-]
+AUTOLOAD = ["app"]

--- a/config/database.py
+++ b/config/database.py
@@ -1,8 +1,7 @@
 """Database Settings """
-from src.masonite import env
-from masoniteorm.query import QueryBuilder
+from masonite import env
 from masoniteorm.connections import ConnectionResolver
-from src.masonite.environment import LoadEnvironment
+from masonite.environment import LoadEnvironment
 
 
 LoadEnvironment()

--- a/config/database.py
+++ b/config/database.py
@@ -1,45 +1,60 @@
-""" Database Settings """
+"""Database Settings """
+from src.masonite import env
+from masoniteorm.query import QueryBuilder
+from masoniteorm.connections import ConnectionResolver
+from src.masonite.environment import LoadEnvironment
 
-import os
-
-from masonite.environment import LoadEnvironment
-from orator import DatabaseManager, Model
-
-"""
-|--------------------------------------------------------------------------
-| Load Environment Variables
-|--------------------------------------------------------------------------
-|
-| Loads in the environment variables when this page is imported.
-|
-"""
 
 LoadEnvironment()
 
 """
 |--------------------------------------------------------------------------
-| Database Settings
+| Databases connectors details
 |--------------------------------------------------------------------------
 |
-| Set connection database settings here as a dictionary. Follow the
-| format below to create additional connection settings.
-|
-| @see Orator migrations documentation for more info
+| Setup details of the database connectors you want to use.
 |
 """
 
 DATABASES = {
-    'default': os.environ.get('DB_DRIVER'),
+    'default': env('DB_CONNECTION', 'sqlite'),
     'sqlite': {
         'driver': 'sqlite',
-        'database': os.environ.get('DB_DATABASE')
-    },
-    os.environ.get('DB_DRIVER'): {
-        'driver': os.environ.get('DB_DRIVER'),
-        'database': os.environ.get('DB_DATABASE'),
+        'database': env('SQLITE_DB_DATABASE', 'masonite.sqlite3'),
         'prefix': ''
-    }
+    },
+    "mysql": {
+        "driver": "mysql",
+        "host": env('DB_HOST'),
+        "user": env("DB_USERNAME"),
+        "password": env("DB_PASSWORD"),
+        "database": env("DB_DATABASE"),
+        "port": env('DB_PORT'),
+        "prefix": "",
+        "grammar": "mysql",
+        "options": {
+            "charset": "utf8mb4",
+        },
+    },
+    "postgres": {
+        "driver": "postgres",
+        "host": env('DB_HOST'),
+        "user": env("DB_USERNAME"),
+        "password": env("DB_PASSWORD"),
+        "database": env("DB_DATABASE"),
+        "port": env('DB_PORT'),
+        "prefix": "",
+        "grammar": "postgres",
+    },
+    'mssql': {
+        'driver': 'mssql',
+        'host': env('MSSQL_DATABASE_HOST'),
+        'user': env('MSSQL_DATABASE_USER'),
+        'password': env('MSSQL_DATABASE_PASSWORD'),
+        'database': env('MSSQL_DATABASE_DATABASE'),
+        'port': env('MSSQL_DATABASE_PORT'),
+        'prefix': ''
+    },
 }
 
-DB = DatabaseManager(DATABASES)
-Model.set_connection_resolver(DB)
+DB = ConnectionResolver().set_connection_details(DATABASES)

--- a/config/middleware.py
+++ b/config/middleware.py
@@ -19,7 +19,6 @@ from app.http.middleware.LoadUserMiddleware import LoadUserMiddleware
 
 HTTP_MIDDLEWARE = [
     LoadUserMiddleware,
-    CsrfMiddleware,
     ResponseMiddleware
 ]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-masonite>=2.3,<2.4.0
+masonite>=3.0,<4.0
 pytest
 flake8
 pwnedapi==1.0.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ flake8
 pwnedapi==1.0.2
 hfilesize==0.1.0
 masonite-dot==0.0.5
+pytz

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,6 @@ setup(
 
         # Specify the Python versions you support here. In particular, ensure
         # that you indicate whether you support Python 2, Python 3 or both.
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',

--- a/setup.py
+++ b/setup.py
@@ -37,9 +37,10 @@ setup(
 
         # Specify the Python versions you support here. In particular, ensure
         # that you indicate whether you support Python 2, Python 3 or both.
-        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3 :: Only',
 
         'Topic :: Software Development :: Libraries',

--- a/src/masonite/validation/MessageBag.py
+++ b/src/masonite/validation/MessageBag.py
@@ -1,10 +1,9 @@
 """The Message Bag Module"""
 
 import json
-from masonite.response import Responsable
 
 
-class MessageBag(Responsable):
+class MessageBag:
     def __init__(self, items={}):
         self.items = items
 

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -3,6 +3,14 @@ from masonite.routes import Get
 
 
 class TestDecorators(TestCase):
+    @classmethod
+    def setUpClass(cls):
+        pass
+
+    @classmethod
+    def tearDownClass(cls):
+        pass
+
     def setUp(self):
         super().setUp()
         self.routes(

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -1549,6 +1549,14 @@ class TestValidationFactory(unittest.TestCase):
 
 
 class TestValidationProvider(TestCase):
+    @classmethod
+    def setUpClass(cls):
+        pass
+
+    @classmethod
+    def tearDownClass(cls):
+        pass
+
     def setUp(self):
         super().setUp()
         self.app = self.container


### PR DESCRIPTION
Fixes usage when used outside a masonite project:
This does not raise errors anymore.

It has been tested on this small snippet outside a Masonite project:
```python
from masonite.validation import Validator, required, exists, accepted

payload = {
    'user': 'username123',
    'company': '',
    'terms': 'on' # For checkboxes
}

errors = Validator().validate(
    payload,
    required(['user', 'company', 'terms']),
    accepted('terms')
  )

print(errors)
```